### PR TITLE
Use Julia v0.6 syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Compat
 StaticArrays

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,13 +2,13 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-abstract Object{N} # a solid geometric object in N dimensions
-Base.ndims{N}(o::Object{N}) = N
+abstract type Object{N} end # a solid geometric object in N dimensions
+Base.ndims(o::Object{N}) where N = N
 
 export Object, normal, bounds
 
-Base.in{N}(x::AbstractVector, o::Object{N}) = SVector{N}(x) in o
-normal{N}(x::AbstractVector, o::Object{N}) = normal(SVector{N}(x), o)
+Base.in(x::AbstractVector, o::Object{N}) where N = SVector{N}(x) in o
+normal(x::AbstractVector, o::Object{N}) where N = normal(SVector{N}(x), o)
 
 include("sphere.jl")
 include("box.jl")

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,6 +1,6 @@
 export Box
 
-type Box{N,D} <: Object{N}
+struct Box{N,D} <: Object{N}
     c::SVector{N,Float64} # box center
     p::SMatrix{N,N,Float64} # projection matrix to box coordinates
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
@@ -11,10 +11,10 @@ function Box(c::AbstractVector, d::AbstractVector,
              axes=eye(length(c),length(c)), # columns are axes unit vectors
              data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt(sumabs2(axes,2))), d*0.5, data)
+    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), d*0.5, data)
 end
 
-function Base.in{N}(x::SVector{N}, b::Box{N})
+function Base.in(x::SVector{N}, b::Box{N}) where N
     d = b.p * (x - b.c)
     for i = 1:N
         abs(d[i]) > b.r[i] && return false
@@ -22,7 +22,7 @@ function Base.in{N}(x::SVector{N}, b::Box{N})
     return true
 end
 
-function normal{N}(x::SVector{N}, b::Box{N})
+function normal(x::SVector{N}, b::Box{N}) where N
     d = b.p * (x - b.c)
     (m,i) = findmin(abs.(abs.(d) - b.r))
     return SVector{N}(b.p[i,:]) * sign(d[i])

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,23 +1,23 @@
 export Cylinder
 
-type Cylinder{N,D} <: Object{N}
+struct Cylinder{N,D} <: Object{N}
     c::SVector{N,Float64} # Cylinder center
     a::SVector{N,Float64}   # axis unit vector
     r::Float64          # radius
     h2::Float64         # height * 0.5
     data::D             # auxiliary data
 end
-Cylinder{D}(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data::D=nothing) =
+Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data::D=nothing) where D =
     Cylinder{length(c),D}(c, normalize(a), r, h * 0.5, data)
 
-function Base.in{N}(x::SVector{N}, s::Cylinder{N})
+function Base.in(x::SVector{N}, s::Cylinder{N}) where N
     d = x - s.c
     p = dot(d, s.a)
     abs(p) > s.h2 && return false
-    return sumabs2(d - p*s.a) ≤ s.r^2
+    return sum(abs2, d - p*s.a) ≤ s.r^2
 end
 
-function normal{N}(x::SVector{N}, s::Cylinder{N})
+function normal(x::SVector{N}, s::Cylinder{N}) where N
     d = x - s.c
     p = dot(d, s.a)
     p > s.h2 && return s.a
@@ -48,5 +48,5 @@ function bounds(s::Cylinder)
     e1, e2 = endcircles(s)
     l1, u1 = bounds(e1)
     l2, u2 = bounds(e2)
-    return min(l1,l2), max(u1,u2)
+    return min.(l1,l2), max.(u1,u2)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,22 +1,22 @@
 export Ellipsoid
 
-type Ellipsoid{N,D} <: Object{N}
+struct Ellipsoid{N,D} <: Object{N}
     c::SVector{N,Float64} # Ellipsoid center
     p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
     data::D             # auxiliary data
-    Ellipsoid(c,ri2,p,data) = new(c,ri2,p,data)
+    Ellipsoid{N,D}(c,ri2,p,data) where {N,D} = new(c,ri2,p,data)
 end
 
 function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),length(c)), # columns are axes unit vectors
                    data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt(sumabs2(axes,2))), (d*0.5) .^ -2, data)
+    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), (d*0.5) .^ -2, data)
 end
 
-Base.in{N}(x::SVector{N}, b::Ellipsoid{N}) = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
+Base.in(x::SVector{N}, b::Ellipsoid{N}) where N = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 
-normal{N}(x::SVector{N}, b::Ellipsoid{N}) = normalize(Ac_mul_B(b.p, b.ri2 .* (b.p * (x - b.c))))
+normal(x::SVector{N}, b::Ellipsoid{N}) where N = normalize(Ac_mul_B(b.p, b.ri2 .* (b.p * (x - b.c))))
 
 function bounds(b::Ellipsoid)
     # this is the bounding box for the axes-aligned box around the ellipsoid,

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,11 +1,11 @@
 export Sphere
 
-type Sphere{N,D} <: Object{N}
+struct Sphere{N,D} <: Object{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
 end
-Sphere{D}(c::AbstractVector, r::Real, data::D=nothing) = Sphere{length(c),D}(c, r, data)
-Base.in{N}(x::SVector{N}, s::Sphere{N}) = sumabs2(x - s.c) ≤ s.r^2
-normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
+Sphere(c::AbstractVector, r::Real, data::D=nothing) where D = Sphere{length(c),D}(c, r, data)
+Base.in(x::SVector{N}, s::Sphere{N}) where N = sum(abs2, x - s.c) ≤ s.r^2
+normal(x::SVector{N}, s::Sphere{N}) where N = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ function checktree{N}(t::KDTree{N}, olist::Vector{Object{N}}, ntrials=10^3)
     ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(olist)
         lbi,ubi = bounds(olist[i])
-        lb = min(lb,lbi)
-        ub = max(ub,ubi)
+        lb = min.(lb,lbi)
+        ub = max.(ub,ubi)
     end
     for i = 1:ntrials
         x = randnb(lb,ub)


### PR DESCRIPTION
This PR incorporates Julia v0.6 syntax to the package.  Now that `StaticArrays` uses Julia v0.6 (https://github.com/JuliaArrays/StaticArrays.jl/pull/183), it seems reasonable to require v0.6 as the minimum Julia version.

Here is the summary of changes:
- `abstract` → `abstract type ... end`
- `type` → `struct` (instead of `mutable struct`, assuming the internal data of `Object` do not change in most cases)
- use of `where ...` for parametrization
- `sumabs2` → `sum(abs2, ...)`
- dot syntax for `min`, `max`, `sqrt`, etc
