### PR TITLE
Eliminate deprecation warnings in Julia v0.6

### DIFF
--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,7 +2,7 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-abstract Object{N} # a solid geometric object in N dimensions
+@compat abstract type Object{N} end # a solid geometric object in N dimensions
 Base.ndims{N}(o::Object{N}) = N
 
 export Object, normal, bounds

--- a/src/box.jl
+++ b/src/box.jl
@@ -11,7 +11,7 @@ function Box(c::AbstractVector, d::AbstractVector,
              axes=eye(length(c),length(c)), # columns are axes unit vectors
              data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt(sumabs2(axes,2))), d*0.5, data)
+    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), d*0.5, data)
 end
 
 function Base.in{N}(x::SVector{N}, b::Box{N})

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -14,7 +14,7 @@ function Base.in{N}(x::SVector{N}, s::Cylinder{N})
     d = x - s.c
     p = dot(d, s.a)
     abs(p) > s.h2 && return false
-    return sumabs2(d - p*s.a) ≤ s.r^2
+    return sum(abs2,d - p*s.a) ≤ s.r^2
 end
 
 function normal{N}(x::SVector{N}, s::Cylinder{N})
@@ -48,5 +48,5 @@ function bounds(s::Cylinder)
     e1, e2 = endcircles(s)
     l1, u1 = bounds(e1)
     l2, u2 = bounds(e2)
-    return min(l1,l2), max(u1,u2)
+    return min.(l1,l2), max.(u1,u2)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -5,13 +5,13 @@ type Ellipsoid{N,D} <: Object{N}
     p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
     data::D             # auxiliary data
-    Ellipsoid(c,ri2,p,data) = new(c,ri2,p,data)
+    (::Type{Ellipsoid{N,D}}){N,D}(c,ri2,p,data) = new{N,D}(c,ri2,p,data)  # inner constructor compatible with both v0.5 and v0.6
 end
 
 function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),length(c)), # columns are axes unit vectors
                    data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt(sumabs2(axes,2))), (d*0.5) .^ -2, data)
+    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), (d*0.5) .^ -2, data)
 end
 
 Base.in{N}(x::SVector{N}, b::Ellipsoid{N}) = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -19,10 +19,10 @@ type KDTree{K}
     x::Float64
     left::KDTree  # objects ≤ x in coordinate ix
     right::KDTree # objects > x in coordinate ix
-    KDTree(o::AbstractVector{Object{K}}) = new(o, 0)
-    function KDTree(x::Real, ix::Integer, left::KDTree{K}, right::KDTree{K})
+    (::Type{KDTree{K}}){K}(o::AbstractVector{Object{K}}) = new{K}(o, 0)  # inner constructor compatible with both v0.5 and v0.6
+    function (::Type{KDTree{K}}){K}(x::Real, ix::Integer, left::KDTree{K}, right::KDTree{K})  # inner constructor compatible with both v0.5 and v0.6
         1 ≤ ix ≤ K || throw(BoundsError())
-        new(Object{K}[], ix, x, left, right)
+        new{K}(Object{K}[], ix, x, left, right)
     end
 end
 

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -6,6 +6,6 @@ type Sphere{N,D} <: Object{N}
     data::D             # auxiliary data
 end
 Sphere{D}(c::AbstractVector, r::Real, data::D=nothing) = Sphere{length(c),D}(c, r, data)
-Base.in{N}(x::SVector{N}, s::Sphere{N}) = sumabs2(x - s.c) ≤ s.r^2
+Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
 normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ function checktree{N}(t::KDTree{N}, olist::Vector{Object{N}}, ntrials=10^3)
     ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(olist)
         lbi,ubi = bounds(olist[i])
-        lb = min(lb,lbi)
-        ub = max(ub,ubi)
+        lb = min.(lb,lbi)
+        ub = max.(ub,ubi)
     end
     for i = 1:ntrials
         x = randnb(lb,ub)


### PR DESCRIPTION
This PR eliminates various deprecation warnings in Julia v0.6 while keeping it compatible with v0.5.

Change summary:
- Use dot syntax for `min`, `max`, `sqrt`, etc
- `sumabs2` → `sum(abs2, ...)`
- `abstract TypeName` → `@compat abstract type TypeName end`
- The v0.6 inner constructor syntax cannot be used even with the `Compat` package (see [here](https://github.com/JuliaLang/Compat.jl/issues/332#issuecomment-285864357)), so use the workaround suggested [here](https://github.com/JuliaLang/Compat.jl/issues/356#issuecomment-300836126).