### PR TITLE
Fix projection matrix in Box and Ellipsoid, and implement precise bounds for Ellipsoid

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -36,7 +36,7 @@ function bounds(b::Box)
     # Below, b.p' .* b.r' would have been conceptually better because its "columns"
     # are scaled axes vectors.  However, then the result is not SMatrix because b.r'
     # is not SVector.  Then, we cannot use maximum(..., Val{2}), which is type-stable
-    # for SMatrix.  The workaround is to calculate b.p .* b.r and take transpose.
+    # for SMatrix.  A workaround is to calculate b.p .* b.r and take transpose.
     A = (b.p .* b.r)'  # SMatrix
 
     m = maximum(A * signmatrix(b), Val{2})[:,1] # extrema of all 2^N corners of the box

--- a/src/box.jl
+++ b/src/box.jl
@@ -11,7 +11,7 @@ function Box(c::AbstractVector, d::AbstractVector,
              axes=eye(length(c),length(c)), # columns are axes unit vectors
              data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), d*0.5, data)
+    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), d*0.5, data)
 end
 
 function Base.in{N}(x::SVector{N}, b::Box{N})
@@ -33,7 +33,12 @@ signmatrix(b::Object{2}) = SMatrix{2,4}(1,1, -1,1, 1,-1, -1,-1)
 signmatrix(b::Object{3}) = SMatrix{3,8}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1, -1,-1,1, -1,1,-1, 1,-1,-1, -1,-1,-1)
 
 function bounds(b::Box)
-    A = inv(b.p) .* b.r' # array of scaled axes vectors.
-    m = maximum(A * signmatrix(b), 2)[:,1] # extrema of all 2^N corners of the box
+    # Below, b.p' .* b.r' would have been conceptually better because its "columns"
+    # are scaled axes vectors.  However, then the result is not SMatrix because b.r'
+    # is not SVector.  Then, we cannot use maximum(..., Val{2}), which is type-stable
+    # for SMatrix.  The workaround is to calculate b.p .* b.r and take transpose.
+    A = (b.p .* b.r)'  # SMatrix
+
+    m = maximum(A * signmatrix(b), Val{2})[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -11,17 +11,50 @@ end
 function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),length(c)), # columns are axes unit vectors
                    data=nothing)
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,2))), (d*0.5) .^ -2, data)
+    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), (d*0.5) .^ -2, data)
 end
 
 Base.in{N}(x::SVector{N}, b::Ellipsoid{N}) = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 
 normal{N}(x::SVector{N}, b::Ellipsoid{N}) = normalize(Ac_mul_B(b.p, b.ri2 .* (b.p * (x - b.c))))
 
-function bounds(b::Ellipsoid)
-    # this is the bounding box for the axes-aligned box around the ellipsoid,
-    # which may be bigger than necessary.  TODO: compute true bounding box
-    A = inv(b.p) .* (b.ri2 .^ -0.5)' # array of scaled axes vectors.
-    m = maximum(A * signmatrix(b), 2)[:,1] # extrema of all 2^N corners of the box
+function boundpts{N}(b::Ellipsoid{N})
+    # Return the points tangential to the bounding box.
+    # For N = 3, it returns three points at which the direction normals are +x, +y, +z
+    # directions, respectively.
+
+    r2 = 1./b.ri2
+    ndir = b.p  # Cartesian directions in ellipsoid coordinates: b.p * eye(3)
+
+    # In the ellipsoid coordinates, the point on the ellipsoid where the direction normal is
+    # n is (n .* r2) / sqrt(r2' * n.^2).  Below is the broadcasted version of this over a
+    # matrix n, whose each column is a direction normal.  Once calculated, we need to
+    # change the coordinates back to the original coordinates.
+    #
+    # This operation can be written M = b.p' * ((ndir .* r2) ./ sqrt.(r2' * ndir.^2)), but
+    # the resulting M is not an SMatrix.  (The calculation involves broadcasted division by
+    # a row vector, which leads to a non-SMatrix.)  Therefore, we first calculate M'
+    # (which remains SMatrix) and recover M.
+    M = (((ndir .* r2)' ./ sqrt.(ndir'.^2 * r2)) * b.p)'
+
+    return M
+end
+
+# NaN-ignoring max.
+nanmax(x,y) = isnan(x) ? y : (isnan(y) ? x : max(x,y))
+
+function bounds{N}(b::Ellipsoid{N})
+    M = boundpts(b)
+
+    # Note that when M does not include NaN, we can simply set m = diag(M), because the
+    # first (second, third) column of M is the point on the ellipsoid at which the normal
+    # vector is +x (+y, +z).  Therefore, the x (y, z) point of the first (second, third)
+    # column has the largest x (y, z) coordinate.
+    #
+    # However, if one of a, b, c is zero, the shape is a disk.  Then one column of M can be
+    # completely filled with NaN.  This column must not be counted as a bounding point, so
+    # we apply nanmax by StaticArrays.reducedim along the row direction.
+    m = reducedim(nanmax, M, Val{2})[:,1]
+
     return (b.c-m,b.c+m)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using GeometryPrimitives, StaticArrays, Base.Test
 
 const rtol = Base.rtoldefault(Float64)
-const one⁻ = 1-rtol  # slightly less than 1
-const one⁺ = 1+rtol  # slightly greater than 1
+const one⁻ = 1 - rtol  # slightly less than 1
+const one⁺ = 1 + rtol  # slightly greater than 1
 
 Base.isapprox(a::Tuple, b::Tuple; kws...) = all(p -> isapprox(p...; kws...), zip(a,b))
 const rng = MersenneTwister(0) # test with reproducible pseudorandom numbers
@@ -81,8 +81,8 @@ end
 
             Cin = R * (GeometryPrimitives.signmatrix(br) .* (one⁻ .* [r1,r2]))  # around corners, inside
             Cout = R * (GeometryPrimitives.signmatrix(br) .* (one⁺ .* [r1,r2]))  # around corners, outside
-            @test all([Cin[:,j] for j = 1:4] .∈ br)
-            @test all([Cout[:,j] for j = 1:4] .∉ br)
+            for j = 1:4; @test Cin[:,j] ∈ br; end
+            for j = 1:4; @test Cout[:,j] ∉ br; end
 
             @test normal(R*[1.1r1, 0], br) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
@@ -116,8 +116,8 @@ end
             bp1, bp2 = bp[:,1], bp[:,2]
 
             # Test the two bounding points are on the ellipsoid perimeter.
-            @test all(one⁻ .* (bp1, bp2) .∈ er)
-            @test all(one⁺ .* (bp1, bp2) .∉ er)
+            @test (one⁻ * bp1 ∈ er) && (one⁻ * bp2 ∈ er)
+            @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
             # Test the normal vector at the two bounding points are the x- and y-directions.
             @test normal(bp1, er) ≈ [1,0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
 using GeometryPrimitives, StaticArrays, Base.Test
+
+const rtol = Base.rtoldefault(Float64)
+const one⁻ = 1-rtol  # slightly less than 1
+const one⁺ = 1+rtol  # slightly greater than 1
+
 Base.isapprox(a::Tuple, b::Tuple; kws...) = all(p -> isapprox(p...; kws...), zip(a,b))
 const rng = MersenneTwister(0) # test with reproducible pseudorandom numbers
 
@@ -17,7 +22,7 @@ function checkbounds{N}(o::Object{N}, ntrials=10^4)
     lb,ub = bounds(o)
     for i = 1:ntrials
         x = randnb(lb,ub)
-        x ∉ o || inbounds(x,lb,ub) || return false
+        x ∉ o || inbounds(x,lb,ub) || return false  # return false if o - (bounding box) is nonempty
     end
     return true
 end
@@ -67,6 +72,30 @@ end
             @test checkbounds(Box([0,0], [2,4], [1 1; 1 -1]))
         end
 
+        @testset "Box, rotated" begin
+            ax1, ax2 = [1,-1], [1,1]
+            r1, r2 = 1, 2  # "radii"
+            br = Box([0,0], [2r1, 2r2], [ax1 ax2])
+
+            R = [normalize(ax1) normalize(ax2)]  # rotation matrix
+
+            Cin = R * (GeometryPrimitives.signmatrix(br) .* (one⁻ .* [r1,r2]))  # around corners, inside
+            Cout = R * (GeometryPrimitives.signmatrix(br) .* (one⁺ .* [r1,r2]))  # around corners, outside
+            @test all([Cin[:,j] for j = 1:4] .∈ br)
+            @test all([Cout[:,j] for j = 1:4] .∉ br)
+
+            @test normal(R*[1.1r1, 0], br) ≈ R*[1,0]
+            @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
+            @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
+            @test normal(R*[0, -1.1r2], br) ≈ R*[0,-1]
+            @test normal(R*[1.1r1, 1.01r2], br) ≈ R*[0,1]
+
+            xmax = (R*[r1,r2])[1]
+            ymax = (R*[-r1,r2])[2]
+            @test bounds(br) ≈ (-[xmax,ymax], [xmax,ymax])
+            @test checkbounds(br)
+        end
+
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [2,4])
             @test [0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e
@@ -79,6 +108,27 @@ end
             @test checkbounds(Ellipsoid([0,0], [2,4], [1 1; 1 -1]))
         end
 
+        @testset "Ellipsoid, rotated" begin
+            θ = π/3
+            er = Ellipsoid([0,0], [2,4], [cos(θ) sin(θ); sin(θ) -cos(θ)])
+            bp = GeometryPrimitives.boundpts(er)
+
+            bp1, bp2 = bp[:,1], bp[:,2]
+
+            # Test the two bounding points are on the ellipsoid perimeter.
+            @test all(one⁻ .* (bp1, bp2) .∈ er)
+            @test all(one⁺ .* (bp1, bp2) .∉ er)
+
+            # Test the normal vector at the two bounding points are the x- and y-directions.
+            @test normal(bp1, er) ≈ [1,0]
+            @test normal(bp2, er) ≈ [0,1]
+
+            xmax, ymax = bp1[1], bp2[2]
+
+            @test bounds(er) == ([-xmax, -ymax], [xmax, ymax])
+            @test checkbounds(er)
+        end
+
         @testset "Cylinder" begin
             c = Cylinder([0,0,0], 0.3, [0,0,1], 2.2)
             @test [0.2,0.2,1] ∈ c
@@ -86,7 +136,7 @@ end
             @test [0.2,0.25,1] ∉ c
             @test normal([0.1,0.2,-1.3], c) == [0,0,-1]
             @test normal([0.31, 0, 0.3], c) == [1,0,0]
-            @test bounds(c) == ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
+            @test bounds(c) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
         end


### PR DESCRIPTION
This PR corrects a small bug in the projection matrices in the outer constructors of `Box` and `Ellipsoid`.  

A few other improvements:
- Use the type-stable version of `maximum` on `SMatrix` (https://github.com/JuliaArrays/StaticArrays.jl/pull/86).
- Implement the precise `bounds` for rotated `Ellipsoid`.