### PR TITLE
Change the name of the abstract type `Object` to `Shape`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for the user to specify the function `c(x)`.  In many applications,
 `c` will be piecewise constant, and you want to be able to specify
 `c = 1` in one box, `c = 2` in some cylinders, etcetera.   The
 GeometryPrimitives package allows the user to provide a list of
-objects with associated data (in this case, the value of `c`) to
+shapes with associated data (in this case, the value of `c`) to
 define such a `c(x)`.
 
 Furthermore, the application to discretized simulations imposes a couple
@@ -23,13 +23,13 @@ of additional requirements:
 
 * One needs to be able to evaluate `c(x)` a huge number of times (once
   for every point on a grid).  So, we provide a fast O(log n) K-D tree
-  data structure for rapid searching of objects.
+  data structure for rapid searching of shapes.
 
 * Often, one wants to compute the *average* of `c(x)` over a voxel,
   so we provide routines for rapid *approximate* voxel averages.
 
 * Often, one needs not only the value `c(x)` but the normal vector
-  to the nearest object, so we provide normal-vector computation.
+  to the nearest shape, so we provide normal-vector computation.
 
 This package was inspired by the geometry utilities in my
 [Libctl](http://ab-initio.mit.edu/wiki/index.php/Libctl) package.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ notifications:
 
 install:
 # Download most recent Julia Windows binary
-  - ps: (new-shape net.webclient).DownloadFile(
+  - ps: (new-object net.webclient).DownloadFile(
         $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ notifications:
 
 install:
 # Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
+  - ps: (new-shape net.webclient).DownloadFile(
         $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,13 +2,13 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-@compat abstract type Object{N} end # a solid geometric object in N dimensions
-Base.ndims{N}(o::Object{N}) = N
+@compat abstract type Shape{N} end # a solid geometric shape in N dimensions
+Base.ndims{N}(o::Shape{N}) = N
 
-export Object, normal, bounds
+export Shape, normal, bounds
 
-Base.in{N}(x::AbstractVector, o::Object{N}) = SVector{N}(x) in o
-normal{N}(x::AbstractVector, o::Object{N}) = normal(SVector{N}(x), o)
+Base.in{N}(x::AbstractVector, o::Shape{N}) = SVector{N}(x) in o
+normal{N}(x::AbstractVector, o::Shape{N}) = normal(SVector{N}(x), o)
 
 include("sphere.jl")
 include("box.jl")

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,6 +1,6 @@
 export Box
 
-type Box{N,D} <: Object{N}
+type Box{N,D} <: Shape{N}
     c::SVector{N,Float64} # box center
     p::SMatrix{N,N,Float64} # projection matrix to box coordinates
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
@@ -28,9 +28,9 @@ function normal{N}(x::SVector{N}, b::Box{N})
     return SVector{N}(b.p[i,:]) * sign(d[i])
 end
 
-signmatrix(b::Object{1}) = SMatrix{1,2}(1,-1)
-signmatrix(b::Object{2}) = SMatrix{2,4}(1,1, -1,1, 1,-1, -1,-1)
-signmatrix(b::Object{3}) = SMatrix{3,8}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1, -1,-1,1, -1,1,-1, 1,-1,-1, -1,-1,-1)
+signmatrix(b::Shape{1}) = SMatrix{1,2}(1,-1)
+signmatrix(b::Shape{2}) = SMatrix{2,4}(1,1, -1,1, 1,-1, -1,-1)
+signmatrix(b::Shape{3}) = SMatrix{3,8}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1, -1,-1,1, -1,1,-1, 1,-1,-1, -1,-1,-1)
 
 function bounds(b::Box)
     # Below, b.p' .* b.r' would have been conceptually better because its "columns"

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,6 +1,6 @@
 export Cylinder
 
-type Cylinder{N,D} <: Object{N}
+type Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
     a::SVector{N,Float64}   # axis unit vector
     r::Float64          # radius

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,6 +1,6 @@
 export Ellipsoid
 
-type Ellipsoid{N,D} <: Object{N}
+type Ellipsoid{N,D} <: Shape{N}
     c::SVector{N,Float64} # Ellipsoid center
     p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -1,49 +1,49 @@
-# kd tree for fast searching of a list of objects
+# kd tree for fast searching of a list of shapes
 export KDTree
 
 """
-A K-D tree of objects in `K` dimensions.
+A K-D tree of shapes in `K` dimensions.
 
 This is a binary tree.  Each node in the tree divides space along
-coordinate `ix` into objects that overlap the region `≤ x` and `≥ x`.
-The leaves of the tree are just a list of objects `o`.
+coordinate `ix` into shapes that overlap the region `≤ x` and `≥ x`.
+The leaves of the tree are just a list of shapes `o`.
 
 This implementation is a little different from a standard K-D tree,
-because a given object may be in both branches of the tree.  (Normally,
+because a given shape may be in both branches of the tree.  (Normally,
 K-D trees are used for nearest-neighbor searches for a list of *points*,
-not objects of nonzero size.)
+not shapes of nonzero size.)
 """
 type KDTree{K}
-    o::Vector{Object{K}}
+    o::Vector{Shape{K}}
     ix::Int
     x::Float64
-    left::KDTree  # objects ≤ x in coordinate ix
-    right::KDTree # objects > x in coordinate ix
-    (::Type{KDTree{K}}){K}(o::AbstractVector{Object{K}}) = new{K}(o, 0)  # inner constructor compatible with both v0.5 and v0.6
+    left::KDTree  # shapes ≤ x in coordinate ix
+    right::KDTree # shapes > x in coordinate ix
+    (::Type{KDTree{K}}){K}(o::AbstractVector{Shape{K}}) = new{K}(o, 0)  # inner constructor compatible with both v0.5 and v0.6
     function (::Type{KDTree{K}}){K}(x::Real, ix::Integer, left::KDTree{K}, right::KDTree{K})  # inner constructor compatible with both v0.5 and v0.6
         1 ≤ ix ≤ K || throw(BoundsError())
-        new{K}(Object{K}[], ix, x, left, right)
+        new{K}(Shape{K}[], ix, x, left, right)
     end
 end
 
 Base.ndims{K}(::KDTree{K}) = K
 
 """
-    KDTree(objects::AbstractVector{Object{K}})
+    KDTree(shapes::AbstractVector{Shape{K}})
 
 Construct a K-D tree (`KDTree`) representation of a list of
-`objects` in order to enable rapid searching of an object list.
+`shapes` in order to enable rapid searching of an shape list.
 
-When searching the tree, objects that appear earlier in `objects`
-take precedence over objects that appear later.
+When searching the tree, shapes that appear earlier in `shapes`
+take precedence over shapes that appear later.
 """
-function KDTree{K}(o::AbstractVector{Object{K}})
+function KDTree{K}(o::AbstractVector{Shape{K}})
     (length(o) <= 4 || K == 0) && return KDTree{K}(o)
 
     # figure out the best dimension ix to divide over,
     # the dividing plane x, and the number (nl,nr) of
-    # objects that fall into the left and right subtrees
-    b = map(bounds, o) # cartesian bounding boxes of all objects
+    # shapes that fall into the left and right subtrees
+    b = map(bounds, o) # cartesian bounding boxes of all shapes
     ix = 0
     x = 0.0
     nl = nr = typemax(Int)
@@ -59,12 +59,12 @@ function KDTree{K}(o::AbstractVector{Object{K}})
         end
     end
 
-    # don't bother subdividing if it doesn't reduce the # of objects much
+    # don't bother subdividing if it doesn't reduce the # of shapes much
     4*min(nl,nr) > 3*length(o) && return KDTree{K}(o)
 
-    # create the arrays of objects in each subtree
-    ol = Array{Object{K}}(nl)
-    or = Array{Object{K}}(nr)
+    # create the arrays of shapes in each subtree
+    ol = Array{Shape{K}}(nl)
+    or = Array{Shape{K}}(nr)
     il = ir = 0
     for k in eachindex(o)
         if b[k][1][ix] ≤ x
@@ -85,7 +85,7 @@ Base.show{K}(io::IO, kd::KDTree{K}) = print(io, "KDTree{$K} of depth ", depth(kd
 function _show(io::IO, kd::KDTree, indent)
     indentstr = " "^indent
     if kd.ix == 0
-        println(io, indentstr, length(kd.o), " objects")
+        println(io, indentstr, length(kd.o), " shapes")
     else
         println(io, indentstr, "if x[", kd.ix, "] ≤ ", kd.x, ':')
         _show(io, kd.left, indent + 2)
@@ -99,13 +99,13 @@ function Base.show{K}(io::IO, ::MIME"text/plain", kd::KDTree{K})
     _show(io, kd, 0)
 end
 
-function Base.findin{N}(p::SVector{N}, o::Vector{Object{N}})
+function Base.findin{N}(p::SVector{N}, o::Vector{Shape{N}})
     for i in eachindex(o)
         if p ∈ o[i]
-            return Nullable{Object{N}}(o[i])
+            return Nullable{Shape{N}}(o[i])
         end
     end
-    return Nullable{Object{N}}()
+    return Nullable{Shape{N}}()
 end
 
 function Base.findin{N}(p::SVector{N}, kd::KDTree{N})
@@ -123,8 +123,8 @@ end
 """
     findin(p::AbstractVector, kd::KDTree)
 
-Return a `Nullable` container of the first object in `kd` that contains
-the point `p`, or an `isnull` container if no object was found.
+Return a `Nullable` container of the first shape in `kd` that contains
+the point `p`, or an `isnull` container if no shape was found.
 """
 Base.findin{N}(p::AbstractVector, kd::KDTree{N}) = findin(SVector{N}(p), kd)
-Base.findin{N}(p::AbstractVector, o::Vector{Object{N}}) = findin(SVector{N}(p), o)
+Base.findin{N}(p::AbstractVector, o::Vector{Shape{N}}) = findin(SVector{N}(p), o)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,6 +1,6 @@
 export Sphere
 
-type Sphere{N,D} <: Object{N}
+type Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,30 +17,30 @@ function inbounds(x,lb,ub)
     return true
 end
 
-"check the bounding box of o with randomized trials"
-function checkbounds{N}(o::Shape{N}, ntrials=10^4)
-    lb,ub = bounds(o)
+"check the bounding box of s with randomized trials"
+function checkbounds{N}(s::Shape{N}, ntrials=10^4)
+    lb,ub = bounds(s)
     for i = 1:ntrials
         x = randnb(lb,ub)
-        x ∉ o || inbounds(x,lb,ub) || return false  # return false if o - (bounding box) is nonempty
+        x ∉ s || inbounds(x,lb,ub) || return false  # return false if s - (bounding box) is nonempty
     end
     return true
 end
 
-function checktree{N}(t::KDTree{N}, olist::Vector{Shape{N}}, ntrials=10^3)
+function checktree{N}(t::KDTree{N}, slist::Vector{Shape{N}}, ntrials=10^3)
     lb = SVector{N}(fill(Inf,N))
     ub = SVector{N}(fill(-Inf,N))
-    for i in eachindex(olist)
-        lbi,ubi = bounds(olist[i])
+    for i in eachindex(slist)
+        lbi,ubi = bounds(slist[i])
         lb = min.(lb,lbi)
         ub = max.(ub,ubi)
     end
     for i = 1:ntrials
         x = randnb(lb,ub)
-        ot = findin(x, t)
-        ol = findin(x, olist)
-        isnull(ot) == isnull(ol) || return false
-        isnull(ot) || get(ot) == get(ol) || return false
+        st = findin(x, t)
+        sl = findin(x, slist)
+        isnull(st) == isnull(sl) || return false
+        isnull(st) || get(st) == get(sl) || return false
     end
     return true
 end
@@ -143,16 +143,16 @@ end
     end
 
     @testset "KDTree" begin
-        o = Shape{2}[Sphere([i,0], 1, i) for i in 0:20]
-        kd = KDTree(o)
+        s = Shape{2}[Sphere([i,0], 1, i) for i in 0:20]
+        kd = KDTree(s)
         @test GeometryPrimitives.depth(kd) == 4
         @test get(findin([10.1,0], kd)).data == 10
         @test isnull(findin([10.1,1], kd))
-        @test checktree(kd, o)
-        o = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
-        @test checktree(KDTree(o), o)
-        o = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
-        @test checktree(KDTree(o), o)
+        @test checktree(kd, s)
+        s = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
+        @test checktree(KDTree(s), s)
+        s = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
+        @test checktree(KDTree(s), s)
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ function inbounds(x,lb,ub)
 end
 
 "check the bounding box of o with randomized trials"
-function checkbounds{N}(o::Object{N}, ntrials=10^4)
+function checkbounds{N}(o::Shape{N}, ntrials=10^4)
     lb,ub = bounds(o)
     for i = 1:ntrials
         x = randnb(lb,ub)
@@ -27,7 +27,7 @@ function checkbounds{N}(o::Object{N}, ntrials=10^4)
     return true
 end
 
-function checktree{N}(t::KDTree{N}, olist::Vector{Object{N}}, ntrials=10^3)
+function checktree{N}(t::KDTree{N}, olist::Vector{Shape{N}}, ntrials=10^3)
     lb = SVector{N}(fill(Inf,N))
     ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(olist)
@@ -47,7 +47,7 @@ end
 
 @testset "GeometryPrimitives" begin
 
-    @testset "Object" begin
+    @testset "Shape" begin
         @testset "Sphere" begin
             s = Sphere([3,4], 5)
             @test ndims(s) == 2
@@ -143,15 +143,15 @@ end
     end
 
     @testset "KDTree" begin
-        o = Object{2}[Sphere([i,0], 1, i) for i in 0:20]
+        o = Shape{2}[Sphere([i,0], 1, i) for i in 0:20]
         kd = KDTree(o)
         @test GeometryPrimitives.depth(kd) == 4
         @test get(findin([10.1,0], kd)).data == 10
         @test isnull(findin([10.1,1], kd))
         @test checktree(kd, o)
-        o = Object{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
+        o = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
         @test checktree(KDTree(o), o)
-        o = Object{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
+        o = Shape{3}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
         @test checktree(KDTree(o), o)
     end
 


### PR DESCRIPTION
This PR changes the abstract type name `Object`, which is a bit too generic, to `Shape`.