### PR TITLE
Define == and hash for shape types

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -1,6 +1,6 @@
 export Box
 
-immutable Box{N,D} <: Shape{N}
+type Box{N,D} <: Shape{N}
     c::SVector{N,Float64} # box center
     p::SMatrix{N,N,Float64} # projection matrix to box coordinates
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
@@ -13,6 +13,9 @@ function Box(c::AbstractVector, d::AbstractVector,
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
     return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), d*0.5, data)
 end
+
+Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data
+Base.hash(b::Box, h::UInt) = hash(b.c, hash(b.r, hash(b.p, hash(b.data, hash(:Box, h)))))
 
 function Base.in{N}(x::SVector{N}, b::Box{N})
     d = b.p * (x - b.c)

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,6 +1,6 @@
 export Box
 
-type Box{N,D} <: Shape{N}
+immutable Box{N,D} <: Shape{N}
     c::SVector{N,Float64} # box center
     p::SMatrix{N,N,Float64} # projection matrix to box coordinates
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -11,7 +11,7 @@ Cylinder{D}(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data::D=
     Cylinder{length(c),D}(c, normalize(a), r, h * 0.5, data)
 
 Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
-Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Box, h))))))
+Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
 
 function Base.in{N}(x::SVector{N}, s::Cylinder{N})
     d = x - s.c

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,6 +1,6 @@
 export Cylinder
 
-type Cylinder{N,D} <: Shape{N}
+immutable Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
     a::SVector{N,Float64}   # axis unit vector
     r::Float64          # radius

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,6 +1,6 @@
 export Cylinder
 
-immutable Cylinder{N,D} <: Shape{N}
+type Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
     a::SVector{N,Float64}   # axis unit vector
     r::Float64          # radius
@@ -9,6 +9,9 @@ immutable Cylinder{N,D} <: Shape{N}
 end
 Cylinder{D}(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data::D=nothing) =
     Cylinder{length(c),D}(c, normalize(a), r, h * 0.5, data)
+
+Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
+Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Box, h))))))
 
 function Base.in{N}(x::SVector{N}, s::Cylinder{N})
     d = x - s.c

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,6 +1,6 @@
 export Ellipsoid
 
-immutable Ellipsoid{N,D} <: Shape{N}
+type Ellipsoid{N,D} <: Shape{N}
     c::SVector{N,Float64} # Ellipsoid center
     p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
@@ -13,6 +13,9 @@ function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),leng
     length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
     return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), (d*0.5) .^ -2, data)
 end
+
+Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data
+Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Box, h)))))
 
 Base.in{N}(x::SVector{N}, b::Ellipsoid{N}) = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -15,7 +15,7 @@ function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),leng
 end
 
 Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data
-Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Box, h)))))
+Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Ellipsoid, h)))))
 
 Base.in{N}(x::SVector{N}, b::Ellipsoid{N}) = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,6 +1,6 @@
 export Ellipsoid
 
-type Ellipsoid{N,D} <: Shape{N}
+immutable Ellipsoid{N,D} <: Shape{N}
     c::SVector{N,Float64} # Ellipsoid center
     p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -13,7 +13,7 @@ because a given shape may be in both branches of the tree.  (Normally,
 K-D trees are used for nearest-neighbor searches for a list of *points*,
 not shapes of nonzero size.)
 """
-immutable KDTree{K}
+type KDTree{K}
     s::Vector{Shape{K}}
     ix::Int
     x::Float64

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -13,7 +13,7 @@ because a given shape may be in both branches of the tree.  (Normally,
 K-D trees are used for nearest-neighbor searches for a list of *points*,
 not shapes of nonzero size.)
 """
-type KDTree{K}
+immutable KDTree{K}
     s::Vector{Shape{K}}
     ix::Int
     x::Float64

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,6 +1,6 @@
 export Sphere
 
-type Sphere{N,D} <: Shape{N}
+immutable Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,11 +1,13 @@
 export Sphere
 
-immutable Sphere{N,D} <: Shape{N}
+type Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
 end
-Sphere{D}(c::AbstractVector, r::Real, data::D=nothing) = Sphere{length(c),D}(c, r, data)
+Sphere(c::AbstractVector, r::Real, data=nothing) = Sphere{length(c),typeof(data)}(c, r, data)
+Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.data
+Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(b.data, hash(:Box, h))))
 Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
 normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -7,7 +7,7 @@ type Sphere{N,D} <: Shape{N}
 end
 Sphere(c::AbstractVector, r::Real, data=nothing) = Sphere{length(c),typeof(data)}(c, r, data)
 Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.data
-Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(b.data, hash(:Box, h))))
+Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
 Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
 normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
         @testset "Sphere" begin
             s = Sphere([3,4], 5)
             @test s == deepcopy(s)
+            @test hash(s) == hash(deepcopy(s))
             @test ndims(s) == 2
             @test [3,9] ∈ s
             @test [3,9.1] ∉ s
@@ -63,6 +64,7 @@ end
         @testset "Box" begin
             b = Box([0,0], [2,4])  # specify center and radii
             @test b == deepcopy(b)
+            @test hash(b) == hash(deepcopy(b))
             @test [0.3,-1.5] ∈ b
             @test [0.3,-2.5] ∉ b
             @test normal([1.1,0],b) == [1,0]
@@ -87,6 +89,7 @@ end
             for j = 1:4; @test Cout[:,j] ∉ br; end
 
             @test br == deepcopy(br)
+            @test hash(br) == hash(deepcopy(br))
             @test normal(R*[1.1r1, 0], br) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
             @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
@@ -102,6 +105,7 @@ end
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [2,4])
             @test e == deepcopy(e)
+            @test hash(e) == hash(deepcopy(e))
             @test [0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
             @test normal([1.1,0],e) == [1,0]
@@ -121,6 +125,7 @@ end
 
             # Test the two bounding points are on the ellipsoid perimeter.
             @test er == deepcopy(er)
+            @test hash(er) == hash(deepcopy(er))
             @test (one⁻ * bp1 ∈ er) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
@@ -137,6 +142,7 @@ end
         @testset "Cylinder" begin
             c = Cylinder([0,0,0], 0.3, [0,0,1], 2.2)
             @test c == deepcopy(c)
+            @test hash(c) == hash(deepcopy(c))
             @test [0.2,0.2,1] ∈ c
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
     @testset "Shape" begin
         @testset "Sphere" begin
             s = Sphere([3,4], 5)
+            @test s == deepcopy(s)
             @test ndims(s) == 2
             @test [3,9] ∈ s
             @test [3,9.1] ∉ s
@@ -60,7 +61,8 @@ end
         end
 
         @testset "Box" begin
-            b = Box([0,0], [2,4])
+            b = Box([0,0], [2,4])  # specify center and radii
+            @test b == deepcopy(b)
             @test [0.3,-1.5] ∈ b
             @test [0.3,-2.5] ∉ b
             @test normal([1.1,0],b) == [1,0]
@@ -84,6 +86,7 @@ end
             for j = 1:4; @test Cin[:,j] ∈ br; end
             for j = 1:4; @test Cout[:,j] ∉ br; end
 
+            @test br == deepcopy(br)
             @test normal(R*[1.1r1, 0], br) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
             @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
@@ -98,6 +101,7 @@ end
 
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [2,4])
+            @test e == deepcopy(e)
             @test [0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
             @test normal([1.1,0],e) == [1,0]
@@ -116,6 +120,7 @@ end
             bp1, bp2 = bp[:,1], bp[:,2]
 
             # Test the two bounding points are on the ellipsoid perimeter.
+            @test er == deepcopy(er)
             @test (one⁻ * bp1 ∈ er) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
@@ -131,6 +136,7 @@ end
 
         @testset "Cylinder" begin
             c = Cylinder([0,0,0], 0.3, [0,0,1], 2.2)
+            @test c == deepcopy(c)
             @test [0.2,0.2,1] ∈ c
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c


### PR DESCRIPTION
This PR make all the types defined in this module immutable, in order to 
- prevent the users from changing the fields of the instances, and
- make comparison between `Shape` instances easier (e.g., `Box([0,0],[1,1]) == Box([0,0],[1,1])` works after this change).