### PR TITLE
Eliminate instability of bounds and normal

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -1,8 +1,8 @@
 export Box
 
-type Box{N,D} <: Shape{N}
+type Box{N,D,L} <: Shape{N}
     c::SVector{N,Float64} # box center
-    p::SMatrix{N,N,Float64} # projection matrix to box coordinates
+    p::SMatrix{N,N,Float64,L} # projection matrix to box coordinates
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
     data::D             # auxiliary data
 end
@@ -10,8 +10,8 @@ end
 function Box(c::AbstractVector, d::AbstractVector,
              axes=eye(length(c),length(c)), # columns are axes unit vectors
              data=nothing)
-    length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Box{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), d*0.5, data)
+    (N = length(c)) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
+    return Box{N,typeof(data),N^2}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), d*0.5, data)
 end
 
 Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -2,13 +2,18 @@ export Cylinder
 
 type Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
-    a::SVector{N,Float64}   # axis unit vector
     r::Float64          # radius
+    a::SVector{N,Float64}   # axis unit vector
     h2::Float64         # height * 0.5
     data::D             # auxiliary data
+    (::Type{Cylinder{N,D}}){N,D}(c,r,a,h2,data) = new{N,D}(c,r,a,h2,data)
 end
-Cylinder{D}(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data::D=nothing) =
-    Cylinder{length(c),D}(c, normalize(a), r, h * 0.5, data)
+
+Cylinder{N,D}(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) =
+    Cylinder{N,D}(c, r, normalize(a), 0.5h, data)
+
+Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothing) =
+    (N = length(c); Cylinder(SVector{N}(c), r, SVector{N}(a), h, data))
 
 Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
 Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
@@ -29,23 +34,23 @@ function normal{N}(x::SVector{N}, s::Cylinder{N})
 end
 
 const rotate2 = @SMatrix [0.0 1.0; -1.0 0.0] # 2x2 90° rotation matrix
+
 function endcircles(s::Cylinder{2})
     b = rotate2 * s.a
     axes = @SMatrix [s.a[1] b[1]; s.a[2] b[2]]
     d = 2*s.r
-    return(Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d), axes),
-           Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d), axes))
+    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d), axes),
+            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d), axes))
 end
 
 function endcircles(s::Cylinder{3})
     u = abs(s.a[3]) < abs(s.a[1]) ? SVector(0,0,1) : SVector(1,0,0)
     b1 = cross(s.a, u)
     b2 = cross(b1, s.a)
-    axes = [s.a[1] b1[1] b2[1]; s.a[2] b1[2] b2[2]; s.a[3] b1[3] b2[3]]
+    axes = @SMatrix [s.a[1] b1[1] b2[1]; s.a[2] b1[2] b2[2]; s.a[3] b1[3] b2[3]]
     d = 2*s.r
-    et = Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d, d), axes)::Ellipsoid{3,Void,9}  # top disk
-    eb = Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d, d), axes)::Ellipsoid{3,Void,9}  # bottom disk
-    return (et, eb)
+    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d, d), axes), # top disk
+            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d, d), axes))  # bottom disk
 end
 
 function bounds(s::Cylinder)

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -43,8 +43,9 @@ function endcircles(s::Cylinder{3})
     b2 = cross(b1, s.a)
     axes = [s.a[1] b1[1] b2[1]; s.a[2] b1[2] b2[2]; s.a[3] b1[3] b2[3]]
     d = 2*s.r
-    return(Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d, d), axes),
-           Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d, d), axes))
+    et = Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d, d), axes)::Ellipsoid{3,Void,9}  # top disk
+    eb = Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d, d), axes)::Ellipsoid{3,Void,9}  # bottom disk
+    return (et, eb)
 end
 
 function bounds(s::Cylinder)

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,17 +1,17 @@
 export Ellipsoid
 
-type Ellipsoid{N,D} <: Shape{N}
+type Ellipsoid{N,D,L} <: Shape{N}
     c::SVector{N,Float64} # Ellipsoid center
-    p::SMatrix{N,N,Float64} # projection matrix to Ellipsoid coordinates
+    p::SMatrix{N,N,Float64,L} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
     data::D             # auxiliary data
-    (::Type{Ellipsoid{N,D}}){N,D}(c,ri2,p,data) = new{N,D}(c,ri2,p,data)  # inner constructor compatible with both v0.5 and v0.6
+    (::Type{Ellipsoid{N,D,L}}){N,D,L}(c,ri2,p,data) = new{N,D,L}(c,ri2,p,data)  # inner constructor compatible with both v0.5 and v0.6
 end
 
 function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),length(c)), # columns are axes unit vectors
                    data=nothing)
-    length(c) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Ellipsoid{length(c),typeof(data)}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), (d*0.5) .^ -2, data)
+    (N = length(c)) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
+    return Ellipsoid{N,typeof(data),N^2}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), (d*0.5) .^ -2, data)
 end
 
 Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -2,17 +2,19 @@ export Ellipsoid
 
 type Ellipsoid{N,D,L} <: Shape{N}
     c::SVector{N,Float64} # Ellipsoid center
-    p::SMatrix{N,N,Float64,L} # projection matrix to Ellipsoid coordinates
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
+    p::SMatrix{N,N,Float64,L} # projection matrix to Ellipsoid coordinates
     data::D             # auxiliary data
-    (::Type{Ellipsoid{N,D,L}}){N,D,L}(c,ri2,p,data) = new{N,D,L}(c,ri2,p,data)  # inner constructor compatible with both v0.5 and v0.6
+    (::Type{Ellipsoid{N,D,L}}){N,D,L}(c,ri2,p,data) = new{N,D,L}(c,ri2,p,data)
 end
 
-function Ellipsoid(c::AbstractVector, d::AbstractVector, axes=eye(length(c),length(c)), # columns are axes unit vectors
-                   data=nothing)
-    (N = length(c)) == length(d) == size(axes,1) == size(axes,2) || throw(DimensionMismatch())
-    return Ellipsoid{N,typeof(data),N^2}(c, inv(axes ./ sqrt.(sum(abs2,axes,1))), (d*0.5) .^ -2, data)
-end
+Ellipsoid{N,D,L,R<:Real}(c::SVector{N}, d::SVector{N},
+                         axes::SMatrix{N,N,R,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
+                         data::D=nothing) =
+    Ellipsoid{N,D,L}(c, (d*0.5) .^ -2, inv(axes ./ sqrt.(sum(abs2,axes,1))), data)
+
+Ellipsoid(c::AbstractVector, d::AbstractVector, axes::AbstractMatrix=eye(length(c)), data=nothing) =
+    (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
 
 Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data
 Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Ellipsoid, h)))))

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -4,10 +4,15 @@ type Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
+    (::Type{Sphere{N,D}}){N,D}(c,r,data) = new{N,D}(c,r,data)
 end
-Sphere(c::AbstractVector, r::Real, data=nothing) = Sphere{length(c),typeof(data)}(c, r, data)
+
+Sphere{N,D}(c::SVector{N}, r::Real, data::D=nothing) = Sphere{N,D}(c, r, data)
+Sphere(c::AbstractVector, r::Real, data=nothing) = (N = length(c); Sphere(SVector{N}(c), r, data))
+
 Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.data
 Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
+
 Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
 normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,12 +51,12 @@ end
         @testset "Sphere" begin
             s = Sphere([3,4], 5)
             @test s == deepcopy(s)
-            @test hash(s) == hash(deepcopy(s))
-            @test ndims(s) == 2
-            @test [3,9] ∈ s
+            @test @inferred(hash(s)) == hash(deepcopy(s))
+            @test @inferred(ndims(s)) == 2
+            @test @inferred([3,9] ∈ s)
             @test [3,9.1] ∉ s
-            @test normal([-1,2],s) == normalize([-1,2] - [3,4])
-            @test bounds(s) == ([-2,-1],[8,9])
+            @test @inferred(normal([-1,2],s)) == normalize([-1,2] - [3,4])
+            @test @inferred(bounds(s)) == ([-2,-1],[8,9])
             @test checkbounds(s)
             @test checkbounds(Sphere([1,2,3], 2))
         end
@@ -64,13 +64,13 @@ end
         @testset "Box" begin
             b = Box([0,0], [2,4])  # specify center and radii
             @test b == deepcopy(b)
-            @test hash(b) == hash(deepcopy(b))
-            @test [0.3,-1.5] ∈ b
+            @test @inferred(hash(b)) == hash(deepcopy(b))
+            @test @inferred([0.3,-1.5] ∈ b)
             @test [0.3,-2.5] ∉ b
-            @test normal([1.1,0],b) == [1,0]
+            @test @inferred(normal([1.1,0],b)) == [1,0]
             @test normal([-1.1,0],b) == [-1,0]
             @test normal([1.1,2.01],b) == [0,1]
-            @test bounds(b) == ([-1,-2],[1,2])
+            @test @inferred(bounds(b)) == ([-1,-2],[1,2])
             @test bounds(Box([0,0], [2,4], [1 1; 1 -1])) ≈ ([-3*√0.5,-3*√0.5], [3*√0.5,3*√0.5])
             @test checkbounds(b)
             @test checkbounds(Box([0,0], [2,4], [1 1; 1 -1]))
@@ -85,12 +85,12 @@ end
 
             Cin = R * (GeometryPrimitives.signmatrix(br) .* (one⁻ .* [r1,r2]))  # around corners, inside
             Cout = R * (GeometryPrimitives.signmatrix(br) .* (one⁺ .* [r1,r2]))  # around corners, outside
-            for j = 1:4; @test Cin[:,j] ∈ br; end
+            for j = 1:4; @test @inferred(Cin[:,j] ∈ br); end
             for j = 1:4; @test Cout[:,j] ∉ br; end
 
             @test br == deepcopy(br)
-            @test hash(br) == hash(deepcopy(br))
-            @test normal(R*[1.1r1, 0], br) ≈ R*[1,0]
+            @test @inferred(hash(br)) == hash(deepcopy(br))
+            @test @inferred(normal(R*[1.1r1, 0], br)) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
             @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
             @test normal(R*[0, -1.1r2], br) ≈ R*[0,-1]
@@ -98,20 +98,20 @@ end
 
             xmax = (R*[r1,r2])[1]
             ymax = (R*[-r1,r2])[2]
-            @test bounds(br) ≈ (-[xmax,ymax], [xmax,ymax])
+            @test @inferred(bounds(br)) ≈ (-[xmax,ymax], [xmax,ymax])
             @test checkbounds(br)
         end
 
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [2,4])
             @test e == deepcopy(e)
-            @test hash(e) == hash(deepcopy(e))
-            @test [0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e
+            @test @inferred(hash(e)) == hash(deepcopy(e))
+            @test @inferred([0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e)
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
-            @test normal([1.1,0],e) == [1,0]
+            @test @inferred(normal([1.1,0],e)) == [1,0]
             @test normal([-1.1,0],e) == [-1,0]
             @test normal([0,2.01],e) == [0,1]
-            @test bounds(e) == ([-1,-2],[1,2])
+            @test @inferred(bounds(e)) == ([-1,-2],[1,2])
             @test checkbounds(e)
             @test checkbounds(Ellipsoid([0,0], [2,4], [1 1; 1 -1]))
         end
@@ -125,30 +125,30 @@ end
 
             # Test the two bounding points are on the ellipsoid perimeter.
             @test er == deepcopy(er)
-            @test hash(er) == hash(deepcopy(er))
-            @test (one⁻ * bp1 ∈ er) && (one⁻ * bp2 ∈ er)
+            @test @inferred(hash(er)) == hash(deepcopy(er))
+            @test (@inferred(one⁻ * bp1 ∈ er)) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
             # Test the normal vector at the two bounding points are the x- and y-directions.
-            @test normal(bp1, er) ≈ [1,0]
+            @test @inferred(normal(bp1, er)) ≈ [1,0]
             @test normal(bp2, er) ≈ [0,1]
 
             xmax, ymax = bp1[1], bp2[2]
 
-            @test bounds(er) == ([-xmax, -ymax], [xmax, ymax])
+            @test @inferred(bounds(er)) == ([-xmax, -ymax], [xmax, ymax])
             @test checkbounds(er)
         end
 
         @testset "Cylinder" begin
             c = Cylinder([0,0,0], 0.3, [0,0,1], 2.2)
             @test c == deepcopy(c)
-            @test hash(c) == hash(deepcopy(c))
-            @test [0.2,0.2,1] ∈ c
+            @test @inferred(hash(c)) == hash(deepcopy(c))
+            @test @inferred([0.2,0.2,1] ∈ c)
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c
-            @test normal([0.1,0.2,-1.3], c) == [0,0,-1]
+            @test @inferred(normal([0.1,0.2,-1.3], c)) == [0,0,-1]
             @test normal([0.31, 0, 0.3], c) == [1,0,0]
-            @test bounds(c) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
+            @test @inferred(bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,7 +148,7 @@ end
             @test [0.2,0.25,1] ∉ c
             @test @inferred(normal([0.1,0.2,-1.3], c)) == [0,0,-1]
             @test normal([0.31, 0, 0.3], c) == [1,0,0]
-            @test @inferred(bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
+            @test (bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,7 +148,7 @@ end
             @test [0.2,0.25,1] ∉ c
             @test @inferred(normal([0.1,0.2,-1.3], c)) == [0,0,-1]
             @test normal([0.31, 0, 0.3], c) == [1,0,0]
-            @test (bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
+            @test @inferred(bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
         end


### PR DESCRIPTION
This PR eliminates instability of `bounds` and `normal` functions, by adding the extra type parameter `L` to the types `Box` and `Ellipsoid`.  This extra type parameter `L` is used to make the field `p` (projection matrix) of `Box` and `Ellipsoid` concrete, by changing its type from the abstract `SMatrix{N,N,Float64}` to the concrete `SMatrix{N,N,Float64,L}`.

Additionally, this PR surrounds tested functions by `@inferred` macro in `runtests.jl` to make sure all the functions are type-stable.