### PR TITLE
Drop support for Julia 0.5, and use Julia 0.6 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Compat
 StaticArrays

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,13 +2,13 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-@compat abstract type Shape{N} end # a solid geometric shape in N dimensions
-Base.ndims{N}(o::Shape{N}) = N
+abstract type Shape{N} end # a solid geometric shape in N dimensions
+Base.ndims(o::Shape{N}) where {N} = N
 
 export Shape, normal, bounds
 
-Base.in{N}(x::AbstractVector, o::Shape{N}) = SVector{N}(x) in o
-normal{N}(x::AbstractVector, o::Shape{N}) = normal(SVector{N}(x), o)
+Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
+normal(x::AbstractVector, o::Shape{N}) where {N} = normal(SVector{N}(x), o)
 
 include("sphere.jl")
 include("box.jl")

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,17 +1,19 @@
 export Box
 
-type Box{N,D,L} <: Shape{N}
+mutable struct Box{N,D,L} <: Shape{N}
     c::SVector{N,Float64} # box center
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to box coordinates
     data::D             # auxiliary data
-    (::Type{Box{N,D,L}}){N,D,L}(c,r,p,data) = new{N,D,L}(c,r,p,data)
+    Box{N,D,L}(c,r,p,data) where {N,D,L} = new(c,r,p,data)
 end
 
-Box{N,D,L,R<:Real}(c::SVector{N}, d::SVector{N},
-                   axes::SMatrix{N,N,R,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
-                   data::D=nothing) =
-    Box{N,D,L}(c, 0.5*d, inv(axes ./ sqrt.(sum(abs2,axes,1))), data)
+Box(c::SVector{N}, d::SVector{N},
+    axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
+    data::D=nothing) where {N,D,L} =
+    Box{N,D,L}(c, 0.5d, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
+# Use this after StaticArrays issue 242 is fixed:
+#    Box{N,D,L}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
 
 Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
     (N = length(c); Box(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
@@ -19,7 +21,7 @@ Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
 Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data
 Base.hash(b::Box, h::UInt) = hash(b.c, hash(b.r, hash(b.p, hash(b.data, hash(:Box, h)))))
 
-function Base.in{N}(x::SVector{N}, b::Box{N})
+function Base.in(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     for i = 1:N
         abs(d[i]) > b.r[i] && return false
@@ -27,7 +29,7 @@ function Base.in{N}(x::SVector{N}, b::Box{N})
     return true
 end
 
-function normal{N}(x::SVector{N}, b::Box{N})
+function normal(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     (m,i) = findmin(abs.(abs.(d) - b.r))
     return SVector{N}(b.p[i,:]) * sign(d[i])

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,15 +1,15 @@
 export Cylinder
 
-type Cylinder{N,D} <: Shape{N}
+mutable struct Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
     r::Float64          # radius
     a::SVector{N,Float64}   # axis unit vector
     h2::Float64         # height * 0.5
     data::D             # auxiliary data
-    (::Type{Cylinder{N,D}}){N,D}(c,r,a,h2,data) = new{N,D}(c,r,a,h2,data)
+    Cylinder{N,D}(c,r,a,h2,data) where {N,D} = new(c,r,a,h2,data)
 end
 
-Cylinder{N,D}(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) =
+Cylinder(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) where {N,D} =
     Cylinder{N,D}(c, r, normalize(a), 0.5h, data)
 
 Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothing) =
@@ -18,14 +18,14 @@ Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothin
 Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
 Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
 
-function Base.in{N}(x::SVector{N}, s::Cylinder{N})
+function Base.in(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c
     p = dot(d, s.a)
     abs(p) > s.h2 && return false
     return sum(abs2,d - p*s.a) ≤ s.r^2
 end
 
-function normal{N}(x::SVector{N}, s::Cylinder{N})
+function normal(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c
     p = dot(d, s.a)
     p > s.h2 && return s.a

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,18 +1,18 @@
 export Sphere
 
-type Sphere{N,D} <: Shape{N}
+mutable struct Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
-    (::Type{Sphere{N,D}}){N,D}(c,r,data) = new{N,D}(c,r,data)
+    Sphere{N,D}(c,r,data) where {N,D} = new(c,r,data)
 end
 
-Sphere{N,D}(c::SVector{N}, r::Real, data::D=nothing) = Sphere{N,D}(c, r, data)
+Sphere(c::SVector{N}, r::Real, data::D=nothing) where {N,D} = Sphere{N,D}(c, r, data)
 Sphere(c::AbstractVector, r::Real, data=nothing) = (N = length(c); Sphere(SVector{N}(c), r, data))
 
 Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.data
 Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
 
-Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
-normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
+Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2,x - s.c) ≤ s.r^2
+normal(x::SVector{N}, s::Sphere{N}) where {N} = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ function inbounds(x,lb,ub)
 end
 
 "check the bounding box of s with randomized trials"
-function checkbounds{N}(s::Shape{N}, ntrials=10^4)
+function checkbounds(s::Shape{N}, ntrials=10^4) where {N}
     lb,ub = bounds(s)
     for i = 1:ntrials
         x = randnb(lb,ub)
@@ -27,7 +27,7 @@ function checkbounds{N}(s::Shape{N}, ntrials=10^4)
     return true
 end
 
-function checktree{N}(t::KDTree{N}, slist::Vector{Shape{N}}, ntrials=10^3)
+function checktree(t::KDTree{N}, slist::Vector{Shape{N}}, ntrials=10^3) where {N}
     lb = SVector{N}(fill(Inf,N))
     ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(slist)


### PR DESCRIPTION
This PR drop the support for Julia 0.5, and use Julia 0.6 syntax (e.g., `struct` and `where {...}`) repository-wide.