### PR TITLE
Add vxlcut.jl for volume fraction of voxel cut by plane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Compat
 StaticArrays

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -17,4 +17,6 @@ include("cylinder.jl")
 
 include("kdtree.jl")
 
+include("vxlcut.jl")
+
 end # module

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,13 +2,13 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-@compat abstract type Shape{N} end # a solid geometric shape in N dimensions
-Base.ndims{N}(o::Shape{N}) = N
+abstract type Shape{N} end # a solid geometric shape in N dimensions
+Base.ndims(o::Shape{N}) where {N} = N
 
 export Shape, normal, bounds
 
-Base.in{N}(x::AbstractVector, o::Shape{N}) = SVector{N}(x) in o
-normal{N}(x::AbstractVector, o::Shape{N}) = normal(SVector{N}(x), o)
+Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
+normal(x::AbstractVector, o::Shape{N}) where {N} = normal(SVector{N}(x), o)
 
 include("sphere.jl")
 include("box.jl")

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,17 +1,19 @@
 export Box
 
-type Box{N,D,L} <: Shape{N}
+mutable struct Box{N,D,L} <: Shape{N}
     c::SVector{N,Float64} # box center
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to box coordinates
     data::D             # auxiliary data
-    (::Type{Box{N,D,L}}){N,D,L}(c,r,p,data) = new{N,D,L}(c,r,p,data)
+    Box{N,D,L}(c,r,p,data) where {N,D,L} = new(c,r,p,data)
 end
 
-Box{N,D,L,R<:Real}(c::SVector{N}, d::SVector{N},
-                   axes::SMatrix{N,N,R,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
-                   data::D=nothing) =
-    Box{N,D,L}(c, 0.5*d, inv(axes ./ sqrt.(sum(abs2,axes,1))), data)
+Box(c::SVector{N}, d::SVector{N},
+    axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
+    data::D=nothing) where {N,D,L} =
+    Box{N,D,L}(c, 0.5d, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
+# Use this after StaticArrays issue 242 is fixed:
+#    Box{N,D,L}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
 
 Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
     (N = length(c); Box(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
@@ -19,7 +21,7 @@ Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
 Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data
 Base.hash(b::Box, h::UInt) = hash(b.c, hash(b.r, hash(b.p, hash(b.data, hash(:Box, h)))))
 
-function Base.in{N}(x::SVector{N}, b::Box{N})
+function Base.in(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     for i = 1:N
         abs(d[i]) > b.r[i] && return false
@@ -27,7 +29,7 @@ function Base.in{N}(x::SVector{N}, b::Box{N})
     return true
 end
 
-function normal{N}(x::SVector{N}, b::Box{N})
+function normal(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     (m,i) = findmin(abs.(abs.(d) - b.r))
     return SVector{N}(b.p[i,:]) * sign(d[i])

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,15 +1,15 @@
 export Cylinder
 
-type Cylinder{N,D} <: Shape{N}
+mutable struct Cylinder{N,D} <: Shape{N}
     c::SVector{N,Float64} # Cylinder center
     r::Float64          # radius
     a::SVector{N,Float64}   # axis unit vector
     h2::Float64         # height * 0.5
     data::D             # auxiliary data
-    (::Type{Cylinder{N,D}}){N,D}(c,r,a,h2,data) = new{N,D}(c,r,a,h2,data)
+    Cylinder{N,D}(c,r,a,h2,data) where {N,D} = new(c,r,a,h2,data)
 end
 
-Cylinder{N,D}(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) =
+Cylinder(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) where {N,D} =
     Cylinder{N,D}(c, r, normalize(a), 0.5h, data)
 
 Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothing) =
@@ -18,14 +18,14 @@ Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothin
 Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
 Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
 
-function Base.in{N}(x::SVector{N}, s::Cylinder{N})
+function Base.in(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c
     p = dot(d, s.a)
     abs(p) > s.h2 && return false
     return sum(abs2,d - p*s.a) ≤ s.r^2
 end
 
-function normal{N}(x::SVector{N}, s::Cylinder{N})
+function normal(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c
     p = dot(d, s.a)
     p > s.h2 && return s.a

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,18 +1,18 @@
 export Sphere
 
-type Sphere{N,D} <: Shape{N}
+mutable struct Sphere{N,D} <: Shape{N}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
-    (::Type{Sphere{N,D}}){N,D}(c,r,data) = new{N,D}(c,r,data)
+    Sphere{N,D}(c,r,data) where {N,D} = new(c,r,data)
 end
 
-Sphere{N,D}(c::SVector{N}, r::Real, data::D=nothing) = Sphere{N,D}(c, r, data)
+Sphere(c::SVector{N}, r::Real, data::D=nothing) where {N,D} = Sphere{N,D}(c, r, data)
 Sphere(c::AbstractVector, r::Real, data=nothing) = (N = length(c); Sphere(SVector{N}(c), r, data))
 
 Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.data
 Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
 
-Base.in{N}(x::SVector{N}, s::Sphere{N}) = sum(abs2,x - s.c) ≤ s.r^2
-normal{N}(x::SVector{N}, s::Sphere{N}) = normalize(x - s.c)
+Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2,x - s.c) ≤ s.r^2
+normal(x::SVector{N}, s::Sphere{N}) where {N} = normalize(x - s.c)
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/src/vxlcut.jl
+++ b/src/vxlcut.jl
@@ -15,7 +15,7 @@ function corner_bits(vxl::NTuple{2,SVector{3}},  # two ends of solid diagonal of
     # Calculate the bit array that indicates corner contained-ness.
 
     # The bit array is 8 bits (= 1 byte).  The kth bit is 1 if the kth corner is
-    # contained in the half space defined by the plane, an 0 otherwise.  The 8 vertices
+    # contained in the half space defined by the plane, an 0 otherwise.  The 8 corners
     # of the voxel are indexed 1 through 8 in the order of (---), (+--), (-+-), (++-),
     # (--+), (+-+), (-++), (+++), where, e.g., (+--) indicates the corner at the
     # +x, -y, -z corner.
@@ -140,18 +140,18 @@ function volfrac(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, r₀::SVector{3})
 
     const nr₀ = nout⋅r₀
     const cbits = corner_bits(vxl, nout, nr₀)
-    const nvc = count_ones(cbits)  # number of vertices contained
+    const n_corners = count_ones(cbits)  # number of corners contained
 
-    if nvc == 8  # voxel is inside half-space
+    if n_corners == 8  # voxel is inside half-space
         rvol = 1.
-    elseif nvc == 0  # voxel is outside half-space
+    elseif n_corners == 0  # voxel is outside half-space
         rvol = 0.
     elseif isquadsect(cbits) # plane crosses a set of four parallel edges of voxel
         rvol = rvol_quadsect(vxl, nout, nr₀, cbits)
-    elseif nvc ≤ 4 # general cases with nvc ≤ 4
+    elseif n_corners ≤ 4 # general cases with n_corners ≤ 4
         rvol = rvol_gensect(vxl, nout, nr₀, cbits)
-    else  # general cases with nvc ≥ 5
-        assert(nvc ≥ 5)
+    else  # general cases with n_corners ≥ 5
+        assert(n_corners ≥ 5)
         rvol = 1. - rvol_gensect(vxl, .-nout, -nr₀, ~cbits)
     end
 

--- a/src/vxlcut.jl
+++ b/src/vxlcut.jl
@@ -1,0 +1,164 @@
+export volfrac
+
+const X, Y, Z = 1, 2, 3
+const XYZ, YZX, ZXY = (X,Y,Z), (Y,Z,X), (Z,X,Y)
+const UVW = YZX, ZXY, XYZ
+const N, P = 1, 2  # negative, positive
+const NP = (N, P)
+
+corner(vxl::NTuple{2,SVector{3,<:Real}}, sx::Integer, sy::Integer, sz::Integer) =
+    @SVector [vxl[sx][X], vxl[sy][Y], vxl[sz][Z]]
+
+function calc_vcbits(vxl::NTuple{2,SVector{3}},  # two ends of solid diagonal of voxel
+                     nout::SVector{3}, # unit outward normal of plane
+                     nr₀)  # equation of plane: nout⋅(r - r₀) = 0, or nout⋅r = nr₀
+    # Calculate the bit array that indicates corner contained-ness.
+
+    # The bit array is 8 bits (= 1 byte).  The kth bit is 1 if the kth corner is
+    # contained in the half space defined by the plane, an 0 otherwise.  The 8 vertices
+    # of the voxel are indexed 1 through 8 in the order of (---), (+--), (-+-), (++-),
+    # (--+), (+-+), (-++), (+++), where, e.g., (+--) indicates the corner at the
+    # +x, -y, -z corner.
+    vcbits = 0x00
+    bit = 0x01
+    for sz = NP, sy = NP, sx = NP
+        r = corner(vxl, sx, sy, sz)
+        if nout⋅r ≤ nr₀  # corner is inside (nout is outward normal)
+            vcbits |= bit
+        end
+        bit <<= 1
+    end
+
+    return vcbits
+end
+
+function isquadsect(vcbits::UInt8)
+    # Determine if the corner contained-ness bit array corresponds to the case where
+    # the plane crosses one of the three sets of four parallel edges of the voxel.
+
+    return vcbits==0x0F || vcbits==~0x0F || vcbits==0x33 || vcbits==~0x33 || vcbits==0x55 || vcbits==~0x55
+
+    # Equivalent to
+    # n = count_ones(vcbits)
+    # m = count_ones(vcbits & 0x0F)
+    # return n==4 && iseven(m)
+end
+
+function edgedir_quadsect(vcbits::UInt8)
+    # For the cases where the plane crosses a set of four parallel edges of the voxel,
+    # determine which direction those edges lie.
+
+    if vcbits==0x0F || vcbits==~0x0F
+        dir = Z
+    elseif vcbits==0x33 || vcbits==~0x33
+        dir = Y
+    else
+        assert(vcbits==0x55 || vcbits==~0x55)
+        dir = X
+    end
+
+    return dir
+end
+
+function rvol_quadsect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, vcbits::UInt8)
+    # Return the volume fraction for the case where the plane croses a set of four parallel
+    # edges.
+
+    const w = edgedir_quadsect(vcbits)
+    const ∆w = vxl[P][w] - vxl[N][w]
+
+    const u, v, ~ = UVW[w]
+    const nu, nv, nw = nout[u], nout[v], nout[w]
+    const mean_cepts = 4nr₀
+    for sv = NP, su = NP
+        mean_cepts -= nu*vxl[su][u] + nv*vxl[sv][v]
+    end
+    mean_cepts /=  nw * 4∆w
+
+    const sw = nw>0 ? N : P  # nw cannot be 0
+    return abs(mean_cepts - vxl[sw][w]/∆w)
+end
+
+function rvol_gensect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, vcbits::UInt8)
+    # Calculate the volume fraction of most general cases, by cutting out corners from a
+    # triangular pyramid.
+    # Assume count_ones(vcbits) ≤ 4.  Othewise, call this function with flipped nout, nr₀,
+    # vcbits.
+
+    const s = (nout.<0) .+ 1
+    const c = corner(vxl, s...)  # corner coordinates
+    const ∆ = vxl[P] - vxl[N]  # vxl edges
+    const nc = nout .* c
+    rmax, rmid, rmin =  abs.((((nr₀-sum(nc)) .+ nc) ./ nout - c) ./ ∆) # (lengths from corner to intercetps) / (voxel edges)
+
+    # const nx, ny, nz = nout
+    # const sx, sy, sz = ((nx≥0 ? N : P), (ny≥0 ? N : P), (nz≥0 ? N : P))  # signs of corner
+    # const cx, cy, cz = vxl[nX][sx], vxl[nY][sy], vxl[nZ][sz]  # corner coordinates
+    # const ∆x, ∆y, ∆z = vxl[nX][nP]-vxl[nX][nN], vxl[nY][nP]-vxl[nY][nN], vxl[nZ][nP]-vxl[nZ][nN]  # voxel edges
+    # const nxcx, nycy, nzcz = nx*cx, ny*cy, nz*cz
+    # rmax, rmid, rmin =  # (lengths from corner to intercetps) / (voxel edges)
+    #     abs((nr₀-nycy-nzcz)/nx-cx)/∆x, abs((nr₀-nzcz-nxcx)/ny-cy)/∆y, abs((nr₀-nxcx-nycy)/nz-cz)/∆z
+
+
+    # Sort rmax, rmin, rmin properly.
+    if rmax < rmid; rmax, rmid = rmid, rmax; end
+    if rmid < rmin; rmid, rmin = rmin, rmid; end
+    if rmax < rmid; rmax, rmid = rmid, rmax; end
+
+    # Calculate the volume of the triangular pyramid, and cut off appropriate corners.
+    const tmax = 1 - 1/rmax
+    rvol_core = 1 + tmax + tmax^2
+    if rmid > 1
+        tmid = 1 - 1/rmid
+        rvol_core -= rmax * tmid^3
+    end
+    if rmin > 1
+        tmin = 1 - 1/rmin
+        rvol_core -= rmax * tmin^3
+    end
+
+    return rvol_core * rmin * rmid / 6
+end
+
+"""
+    volfrac(voxel, nout, r₀)
+
+Returns the volume fraction `rvol = vol(voxel ⋂ half-space) / vol(voxel)` that indicates how
+much portion of the volume of a voxel is included the half-space defined by a plane.  The
+result is between 0.0 and 1.0, inclusive.  Inside and outside of the half space is
+determined by `nout`, which is the outward normal.  (If a point is on the `nout` side of the
+plane, then it is outside.)
+
+The voxel needs to be aligned with the Cartesian axes, and is described by `v =
+([xn,yn,zn], [xp,yp,zp])` that specifies the x-, y-, z-boundaries of the voxel.  The
+half-space is described by the boundary plane.  The boundary plane is described by the
+outward normal vector `nout = [nx, ny, nz]` and a point `r₀ = [rx, ry, rz]` on the plane.
+`nout` does not have to be normalized.
+"""
+function volfrac(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, r₀::SVector{3})
+    # Return the volume fraction rvol = vol(voxel ⋂ half-space) / vol(voxel).
+
+    const nr₀ = nout⋅r₀
+    const vcbits = calc_vcbits(vxl, nout, nr₀)
+    const nvc = count_ones(vcbits)  # number of vertices contained
+
+    if nvc == 8  # voxel is inside half-space
+        rvol = 1.
+    elseif nvc == 0  # voxel is outside half-space
+        rvol = 0.
+    elseif isquadsect(vcbits) # plane crosses a set of four parallel edges of voxel
+        rvol = rvol_quadsect(vxl, nout, nr₀, vcbits)
+    elseif nvc ≤ 4 # general cases with nvc ≤ 4
+        rvol = rvol_gensect(vxl, nout, nr₀, vcbits)
+    else  # general cases with nvc ≥ 5
+        assert(nvc ≥ 5)
+        rvol = 1. - rvol_gensect(vxl, .-nout, -nr₀, ~vcbits)
+    end
+
+    return rvol
+end
+
+volfrac(vxl::NTuple{2,SVector{2}}, nout::SVector{2}, r₀::SVector{2}) =
+    volfrac((@SVector([vxl[N][1],vxl[N][2],0]), @SVector([vxl[P][1],vxl[P][2],1])),
+            @SVector([nout[1], nout[2], 0]),
+            @SVector([r₀[1], r₀[2], 0]))

--- a/src/vxlcut.jl
+++ b/src/vxlcut.jl
@@ -86,7 +86,7 @@ function rvol_gensect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, cbits:
     # cbits.
 
     const s = (nout.<0) .+ 1
-    const c = corner(vxl, s...)  # corner coordinates
+    const c = corner(vxl, s[X], s[Y], s[Z])  # corner coordinates
     const ∆ = vxl[P] - vxl[N]  # vxl edges
     const nc = nout .* c
     rmax, rmid, rmin =  abs.((((nr₀-sum(nc)) .+ nc) ./ nout - c) ./ ∆) # (lengths from corner to intercetps) / (voxel edges)

--- a/src/vxlcut.jl
+++ b/src/vxlcut.jl
@@ -9,7 +9,7 @@ const NP = (N, P)
 corner(vxl::NTuple{2,SVector{3,<:Real}}, sx::Integer, sy::Integer, sz::Integer) =
     @SVector [vxl[sx][X], vxl[sy][Y], vxl[sz][Z]]
 
-function calc_vcbits(vxl::NTuple{2,SVector{3}},  # two ends of solid diagonal of voxel
+function corner_bits(vxl::NTuple{2,SVector{3}},  # two ends of solid diagonal of voxel
                      nout::SVector{3}, # unit outward normal of plane
                      nr₀)  # equation of plane: nout⋅(r - r₀) = 0, or nout⋅r = nr₀
     # Calculate the bit array that indicates corner contained-ness.
@@ -139,7 +139,7 @@ function volfrac(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, r₀::SVector{3})
     # Return the volume fraction rvol = vol(voxel ⋂ half-space) / vol(voxel).
 
     const nr₀ = nout⋅r₀
-    const vcbits = calc_vcbits(vxl, nout, nr₀)
+    const vcbits = corner_bits(vxl, nout, nr₀)
     const nvc = count_ones(vcbits)  # number of vertices contained
 
     if nvc == 8  # voxel is inside half-space

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ end
         @testset "Sphere" begin
             s = Sphere([3,4], 5)
             @test s == deepcopy(s)
-            @test @inferred(hash(s)) == hash(deepcopy(s))
+            @test hash(s) == hash(deepcopy(s))
             @test @inferred(ndims(s)) == 2
             @test @inferred([3,9] ∈ s)
             @test [3,9.1] ∉ s
@@ -64,7 +64,7 @@ end
         @testset "Box" begin
             b = Box([0,0], [2,4])  # specify center and radii
             @test b == deepcopy(b)
-            @test @inferred(hash(b)) == hash(deepcopy(b))
+            @test hash(b) == hash(deepcopy(b))
             @test @inferred([0.3,-1.5] ∈ b)
             @test [0.3,-2.5] ∉ b
             @test @inferred(normal([1.1,0],b)) == [1,0]
@@ -89,7 +89,7 @@ end
             for j = 1:4; @test Cout[:,j] ∉ br; end
 
             @test br == deepcopy(br)
-            @test @inferred(hash(br)) == hash(deepcopy(br))
+            @test hash(br) == hash(deepcopy(br))
             @test @inferred(normal(R*[1.1r1, 0], br)) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
             @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
@@ -105,7 +105,7 @@ end
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [2,4])
             @test e == deepcopy(e)
-            @test @inferred(hash(e)) == hash(deepcopy(e))
+            @test hash(e) == hash(deepcopy(e))
             @test @inferred([0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e)
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
             @test @inferred(normal([1.1,0],e)) == [1,0]
@@ -125,7 +125,7 @@ end
 
             # Test the two bounding points are on the ellipsoid perimeter.
             @test er == deepcopy(er)
-            @test @inferred(hash(er)) == hash(deepcopy(er))
+            @test hash(er) == hash(deepcopy(er))
             @test (@inferred(one⁻ * bp1 ∈ er)) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
@@ -142,7 +142,7 @@ end
         @testset "Cylinder" begin
             c = Cylinder([0,0,0], 0.3, [0,0,1], 2.2)
             @test c == deepcopy(c)
-            @test @inferred(hash(c)) == hash(deepcopy(c))
+            @test hash(c) == hash(deepcopy(c))
             @test @inferred([0.2,0.2,1] ∈ c)
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ function inbounds(x,lb,ub)
 end
 
 "check the bounding box of s with randomized trials"
-function checkbounds{N}(s::Shape{N}, ntrials=10^4)
+function checkbounds(s::Shape{N}, ntrials=10^4) where {N}
     lb,ub = bounds(s)
     for i = 1:ntrials
         x = randnb(lb,ub)
@@ -27,7 +27,7 @@ function checkbounds{N}(s::Shape{N}, ntrials=10^4)
     return true
 end
 
-function checktree{N}(t::KDTree{N}, slist::Vector{Shape{N}}, ntrials=10^3)
+function checktree(t::KDTree{N}, slist::Vector{Shape{N}}, ntrials=10^3) where {N}
     lb = SVector{N}(fill(Inf,N))
     ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(slist)


### PR DESCRIPTION
This PR adds capability to calculate the volume fraction of the sub-volume of a voxel cut by a plane.  (The main function is `volfrac` in `src/vxlcut.jl`.)

The PR also adds detailed unit tests.