### PR TITLE
Make all concrete shapes inherit from Shape{N,D}

### DIFF
--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -2,7 +2,7 @@ module GeometryPrimitives
 
 using Compat, StaticArrays
 
-abstract type Shape{N} end # a solid geometric shape in N dimensions
+abstract type Shape{N,D} end # a solid geometric shape in N dimensions
 Base.ndims(o::Shape{N}) where {N} = N
 
 export Shape, normal, bounds

--- a/src/box.jl
+++ b/src/box.jl
@@ -1,6 +1,6 @@
 export Box
 
-mutable struct Box{N,D,L} <: Shape{N}
+mutable struct Box{N,D,L} <: Shape{N,D}
     c::SVector{N,Float64} # box center
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to box coordinates

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -1,6 +1,6 @@
 export Cylinder
 
-mutable struct Cylinder{N,D} <: Shape{N}
+mutable struct Cylinder{N,D} <: Shape{N,D}
     c::SVector{N,Float64} # Cylinder center
     r::Float64          # radius
     a::SVector{N,Float64}   # axis unit vector

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -1,6 +1,6 @@
 export Ellipsoid
 
-mutable struct Ellipsoid{N,D,L} <: Shape{N}
+mutable struct Ellipsoid{N,D,L} <: Shape{N,D}
     c::SVector{N,Float64} # Ellipsoid center
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to Ellipsoid coordinates

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,6 +1,6 @@
 export Sphere
 
-mutable struct Sphere{N,D} <: Shape{N}
+mutable struct Sphere{N,D} <: Shape{N,D}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data


### PR DESCRIPTION
This PR adds an additional type parameter `D` to `Shape`, and makes all the concrete shape types inherit from `Shape{N,D}`.