### PR TITLE
Make Ellipsoid constructors to take semiaxes rather than full axes (closes #10)

### DIFF
--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -38,9 +38,8 @@ const rotate2 = @SMatrix [0.0 1.0; -1.0 0.0] # 2x2 90° rotation matrix
 function endcircles(s::Cylinder{2})
     b = rotate2 * s.a
     axes = @SMatrix [s.a[1] b[1]; s.a[2] b[2]]
-    d = 2*s.r
-    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d), axes),
-            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d), axes))
+    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, s.r), axes),
+            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, s.r), axes))
 end
 
 function endcircles(s::Cylinder{3})
@@ -48,9 +47,8 @@ function endcircles(s::Cylinder{3})
     b1 = cross(s.a, u)
     b2 = cross(b1, s.a)
     axes = @SMatrix [s.a[1] b1[1] b2[1]; s.a[2] b1[2] b2[2]; s.a[3] b1[3] b2[3]]
-    d = 2*s.r
-    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, d, d), axes), # top disk
-            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, d, d), axes))  # bottom disk
+    return (Ellipsoid(s.c + s.a*s.h2, SVector(0.0, s.r, s.r), axes), # top disk
+            Ellipsoid(s.c - s.a*s.h2, SVector(0.0, s.r, s.r), axes))  # bottom disk
 end
 
 function bounds(s::Cylinder)

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -8,15 +8,17 @@ mutable struct Ellipsoid{N,D,L} <: Shape{N,D}
     Ellipsoid{N,D,L}(c,ri2,p,data) where {N,D,L} = new(c,ri2,p,data)
 end
 
-Ellipsoid(c::SVector{N}, d::SVector{N},
+Ellipsoid(c::SVector{N}, r::SVector{N},
           axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
           data::D=nothing) where {N,D,L} =
-    Ellipsoid{N,D,L}(c, (0.5d) .^ -2, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
+    Ellipsoid{N,D,L}(c, float.(r).^-2, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
 # Use this after StaticArrays issue 242 is fixed:
-#    Ellipsoid{N,D,L}(c, (0.5d) .^ -2, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
+#    Ellipsoid{N,D,L}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
 
-Ellipsoid(c::AbstractVector, d::AbstractVector, axes::AbstractMatrix=eye(length(c)), data=nothing) =
-    (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
+Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=eye(length(c)), data=nothing) =
+    (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(r), SMatrix{N,N}(axes), data))
+
+Ellipsoid(b::Box{N,<:Any,L}, data::D=nothing) where {N,D,L} = Ellipsoid{N,D,L}(b.c, (b.r).^-2, b.p, data)
 
 Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data
 Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Ellipsoid, h)))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,7 +103,7 @@ end
         end
 
         @testset "Ellipsoid" begin
-            e = Ellipsoid([0,0], [2,4])
+            e = Ellipsoid([0,0], [1,2])
             @test e == deepcopy(e)
             @test hash(e) == hash(deepcopy(e))
             @test @inferred([0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e)
@@ -113,12 +113,17 @@ end
             @test normal([0,2.01],e) == [0,1]
             @test @inferred(bounds(e)) == ([-1,-2],[1,2])
             @test checkbounds(e)
-            @test checkbounds(Ellipsoid([0,0], [2,4], [1 1; 1 -1]))
+            @test checkbounds(Ellipsoid([0,0], [1,2], [1 1; 1 -1]))
+
+            b = Box([0,0], [2,4])
+            eb = Ellipsoid(b)
+            @test e == eb
+            @test hash(e) == hash(eb)
         end
 
         @testset "Ellipsoid, rotated" begin
             θ = π/3
-            er = Ellipsoid([0,0], [2,4], [cos(θ) sin(θ); sin(θ) -cos(θ)])
+            er = Ellipsoid([0,0], [1,2], [cos(θ) sin(θ); sin(θ) -cos(θ)])
             bp = GeometryPrimitives.boundpts(er)
 
             bp1, bp2 = bp[:,1], bp[:,2]
@@ -134,9 +139,13 @@ end
             @test normal(bp2, er) ≈ [0,1]
 
             xmax, ymax = bp1[1], bp2[2]
-
             @test @inferred(bounds(er)) == ([-xmax, -ymax], [xmax, ymax])
             @test checkbounds(er)
+
+            br = Box([0,0], [2,4], [cos(θ) sin(θ); sin(θ) -cos(θ)])
+            ebr = Ellipsoid(br)
+            @test er == ebr
+            @test hash(er) == hash(ebr)
         end
 
         @testset "Cylinder" begin


### PR DESCRIPTION
This PR changes `Ellipsoid` constructors to take semiaxes instead of full axes.

Additionally, this PR adds a capability to construct an `Ellipsoid` out of a `Box` that describes the bounding box of the `Ellipsoid` to construct.