### PR TITLE
Minor cosmetic changes

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -5,7 +5,7 @@ mutable struct Box{N,D,L} <: Shape{N,D}
     r::SVector{N,Float64}   # "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to box coordinates
     data::D             # auxiliary data
-    Box{N,D,L}(c,r,p,data) where {N,D,L} = new(c,r,p,data)
+    Box{N,D,L}(c,r,p,data) where {N,D,L} = new(c,r,p,data)  # suppress default outer constructor
 end
 
 Box(c::SVector{N}, d::SVector{N},

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -6,7 +6,7 @@ mutable struct Cylinder{N,D} <: Shape{N,D}
     a::SVector{N,Float64}   # axis unit vector
     h2::Float64         # height * 0.5
     data::D             # auxiliary data
-    Cylinder{N,D}(c,r,a,h2,data) where {N,D} = new(c,r,a,h2,data)
+    Cylinder{N,D}(c,r,a,h2,data) where {N,D} = new(c,r,a,h2,data)  # suppress default outer constructor
 end
 
 Cylinder(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) where {N,D} =
@@ -15,8 +15,8 @@ Cylinder(c::SVector{N}, r::Real, a::SVector{N}, h::Real=Inf, data::D=nothing) wh
 Cylinder(c::AbstractVector, r::Real, a::AbstractVector, h::Real=Inf, data=nothing) =
     (N = length(c); Cylinder(SVector{N}(c), r, SVector{N}(a), h, data))
 
-Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.a==s2.a && s1.r==s2.r && s1.h2==s2.h2 && s1.data==s2.data
-Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.a, hash(s.r, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
+Base.:(==)(s1::Cylinder, s2::Cylinder) = s1.c==s2.c && s1.r==s2.r && s1.a==s2.a && s1.h2==s2.h2 && s1.data==s2.data
+Base.hash(s::Cylinder, h::UInt) = hash(s.c, hash(s.r, hash(s.a, hash(s.h2, hash(s.data, hash(:Cylinder, h))))))
 
 function Base.in(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -5,7 +5,7 @@ mutable struct Ellipsoid{N,D,L} <: Shape{N,D}
     ri2::SVector{N,Float64} # inverse square of "radius" (semi-axis) in each direction
     p::SMatrix{N,N,Float64,L} # projection matrix to Ellipsoid coordinates
     data::D             # auxiliary data
-    Ellipsoid{N,D,L}(c,ri2,p,data) where {N,D,L} = new(c,ri2,p,data)
+    Ellipsoid{N,D,L}(c,ri2,p,data) where {N,D,L} = new(c,ri2,p,data)  # suppress default outer constructor
 end
 
 Ellipsoid(c::SVector{N}, r::SVector{N},

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -59,7 +59,10 @@ function bounds(b::Ellipsoid{N}) where {N}
     #
     # However, if one of a, b, c is zero, the shape is a disk.  Then one column of M can be
     # completely filled with NaN.  This column must not be counted as a bounding point, so
-    # we apply nanmax by StaticArrays.reducedim along the row direction.
+    # we apply NaN-ignoring maximum by StaticArrays.reducedim along the row direction.
+    #
+    # For the efficient implementation of NaN-ignoring maximum, see
+    # https://discourse.julialang.org/t/inconsistency-between-findmax-and-maximum-with-respect-to-nan/4214/8
     m = reducedim((x,y) -> x<y ? y : x, M, Val{2}, -Inf)[:,1]
 
     return (b.c-m,b.c+m)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -4,7 +4,7 @@ mutable struct Sphere{N,D} <: Shape{N,D}
     c::SVector{N,Float64} # sphere center
     r::Float64          # radius
     data::D             # auxiliary data
-    Sphere{N,D}(c,r,data) where {N,D} = new(c,r,data)
+    Sphere{N,D}(c,r,data) where {N,D} = new(c,r,data)  # suppress default outer constructor
 end
 
 Sphere(c::SVector{N}, r::Real, data::D=nothing) where {N,D} = Sphere{N,D}(c, r, data)


### PR DESCRIPTION
This PR makes minor cosmetic changes: 
- commenting on inner constructors, and 
- changing the order of fields inside `==` and `hash` for `Cylinder` to match their order of declaration in `Cylinder`.