### PR TITLE
Make normal(...) return unit vector for non-rectangular Box

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -31,8 +31,8 @@ end
 
 function normal(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
-    (m,i) = findmin(abs.(abs.(d) - b.r))
-    return SVector{N}(b.p[i,:]) * sign(d[i])
+    ~, i = findmin(abs.(abs.(d) - b.r))
+    return normalize(b.p[i,:] * sign(d[i]))  # b.p[i,:] is non-unit for non-rectangular box
 end
 
 signmatrix(b::Shape{1}) = SMatrix{1,2}(1,-1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,13 @@ end
             @test checkbounds(br)
         end
 
+        @testset "Box, skewed" begin
+            ax1, ax2 = [1,-1], [0,1]
+            r1, r2 = 1, 1  # "radii"
+            bs = Box([0,0], [2r1, 2r2], [ax1 ax2])
+            @test norm(normal([0,1], bs)) ≈ 1   
+        end
+
         @testset "Ellipsoid" begin
             e = Ellipsoid([0,0], [1,2])
             @test e == deepcopy(e)


### PR DESCRIPTION
This PR makes `normal` for `Box` to return a unit vector even if the `Box` is non-rectangular (meaning that its axes are non-orthogonal).