### PR TITLE
Calculate correct bounds for skewed Box

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -40,11 +40,11 @@ signmatrix(b::Shape{2}) = SMatrix{2,4}(1,1, -1,1, 1,-1, -1,-1)
 signmatrix(b::Shape{3}) = SMatrix{3,8}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1, -1,-1,1, -1,1,-1, 1,-1,-1, -1,-1,-1)
 
 function bounds(b::Box)
-    # Below, b.p' .* b.r' would have been conceptually better because its "columns"
+    # Below, inv(b.p) .* b.r' would have been conceptually better because its columns
     # are scaled axes vectors.  However, then the result is not SMatrix because b.r'
     # is not SVector.  Then, we cannot use maximum(..., Val{2}), which is type-stable
-    # for SMatrix.  A workaround is to calculate b.p .* b.r and take transpose.
-    A = (b.p .* b.r)'  # SMatrix
+    # for SMatrix.  A workaround is to calculate inv(b.p') .* b.r and take transpose.
+    A = (inv(b.p') .* b.r)'  # SMatrix
 
     m = maximum(A * signmatrix(b), Val{2})[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,7 @@ end
             @test norm(normal([0,1], bs)) ≈ 1
 
             xmax = (r1*ax1+r2*ax2)[1]
-            ymax = (r1*ax2-r2*ax1)[2]
+            ymax = (r2*ax2-r1*ax1)[2]
             @test @inferred(bounds(bs)) ≈ (-[xmax,ymax],[xmax,ymax])
             @test checkbounds(bs)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,10 +103,15 @@ end
         end
 
         @testset "Box, skewed" begin
-            ax1, ax2 = [1,-1], [0,1]
+            ax1, ax2 = normalize.(([1,-1], [0,1]))
             r1, r2 = 1, 1  # "radii"
             bs = Box([0,0], [2r1, 2r2], [ax1 ax2])
-            @test norm(normal([0,1], bs)) ≈ 1   
+            @test norm(normal([0,1], bs)) ≈ 1
+
+            xmax = (r1*ax1+r2*ax2)[1]
+            ymax = (r1*ax2-r2*ax1)[2]
+            @test @inferred(bounds(bs)) ≈ (-[xmax,ymax],[xmax,ymax])
+            @test checkbounds(bs)
         end
 
         @testset "Ellipsoid" begin


### PR DESCRIPTION
This PR fixes the error in `bounds` for `Box` such that it calculates the correct bounds even if the box is skewed.