### PR TITLE
Add surfpt_nearby that returns nearby surface point

### DIFF
--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -5,10 +5,11 @@ using Compat, StaticArrays
 abstract type Shape{N,D} end # a solid geometric shape in N dimensions
 Base.ndims(o::Shape{N}) where {N} = N
 
-export Shape, normal, bounds
+export Shape, surfpt_nearby, normal, bounds
 
 Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
-normal(x::AbstractVector, o::Shape{N}) where {N} = normal(SVector{N}(x), o)
+surfpt_nearby(x::AbstractVector, o::Shape{N}) where {N} = surfpt_nearby(SVector{N}(x), o)
+normal(x::AbstractVector, o::Shape{N}) where {N} = surfpt_nearby(x, o)[2]
 
 include("sphere.jl")
 include("box.jl")

--- a/src/box.jl
+++ b/src/box.jl
@@ -34,8 +34,8 @@ function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     _m, i = findmin(abs.(abs.(d) - b.r))
     nout = normalize(b.p[i,:])  # direction normal; b.p[i,:] is non-unit for non-rectangular box
     cosθ = nout ⋅ inv(b.p)[:,i]  # θ: angle between nout and ith axis
-    nout *= sign(d[i])
     l∆x = (b.r[i] - abs(d[i])) * cosθ  # distance between surface point and x
+    d[i] < 0 && (nout = -nout)
 
     return x + l∆x*nout, nout
 end

--- a/src/box.jl
+++ b/src/box.jl
@@ -29,10 +29,15 @@ function Base.in(x::SVector{N}, b::Box{N}) where {N}
     return true
 end
 
-function normal(x::SVector{N}, b::Box{N}) where {N}
+function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     _m, i = findmin(abs.(abs.(d) - b.r))
-    return normalize(b.p[i,:] * sign(d[i]))  # b.p[i,:] is non-unit for non-rectangular box
+    nout = normalize(b.p[i,:])  # direction normal; b.p[i,:] is non-unit for non-rectangular box
+    cosθ = nout ⋅ inv(b.p)[:,i]  # θ: angle between nout and ith axis
+    nout *= sign(d[i])
+    l∆x = (b.r[i] - abs(d[i])) * cosθ  # distance between surface point and x
+
+    return x + l∆x*nout, nout
 end
 
 signmatrix(b::Shape{1}) = SMatrix{1,2}(1,-1)

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -31,8 +31,8 @@ function surfpt_nearby(x::SVector{N}, s::Cylinder{N}) where {N}
     q = d - p*s.a
     lp = abs(p)
     lq = norm(q)
-    if abs(lp-s.h2) < abs(lq-s.r)
-        nout = sign(p)*s.a
+    if abs(lp-s.h2) < abs(lq-s.r) || lq == 0
+        nout = p < 0 ? -s.a : s.a
         l∆x = s.h2 - lp
     else
         l∆x = s.r - lq

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -25,12 +25,21 @@ function Base.in(x::SVector{N}, s::Cylinder{N}) where {N}
     return sum(abs2,d - p*s.a) ≤ s.r^2
 end
 
-function normal(x::SVector{N}, s::Cylinder{N}) where {N}
+function surfpt_nearby(x::SVector{N}, s::Cylinder{N}) where {N}
     d = x - s.c
-    p = dot(d, s.a)
-    p > s.h2 && return s.a
-    p < -s.h2 && return -s.a
-    return normalize(d - p*s.a)
+    p = d ⋅ s.a
+    q = d - p*s.a
+    lp = abs(p)
+    lq = norm(q)
+    if abs(lp-s.h2) < abs(lq-s.r)
+        nout = sign(p)*s.a
+        l∆x = s.h2 - lp
+    else
+        l∆x = s.r - lq
+        nout = q / lq
+    end
+
+    return x + l∆x*nout, nout
 end
 
 const rotate2 = @SMatrix [0.0 1.0; -1.0 0.0] # 2x2 90° rotation matrix

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -26,7 +26,11 @@ Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, 
 Base.in(x::SVector{N}, b::Ellipsoid{N}) where {N} = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 
 function surfpt_nearby(x::SVector{N}, b::Ellipsoid{N}) where {N}
-    x == b.c && ((_m,i) = findmax(b.ri2); nout = b.p[i,:]; return (b.c + nout/√b.ri2[i], nout))  # assume b.p is orthogonal
+    if x == b.c
+        _m, i = findmax(b.ri2)
+        nout = b.p[i,:]  # assume b.p is orthogonal
+        return b.c + nout/√b.ri2[i], nout
+    end
 
     # For a given point x and equation of ellipsoid f(x) = 1, find t such that x₀ = x + t*∇f(x)
     # is on the ellipsoid.  Eventually this reduces to a quadratic equation for t.  The

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -26,6 +26,8 @@ Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, 
 Base.in(x::SVector{N}, b::Ellipsoid{N}) where {N} = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 
 function surfpt_nearby(x::SVector{N}, b::Ellipsoid{N}) where {N}
+    x == b.c && ((_m,i) = findmax(b.ri2); nout = b.p[i,:]; return (b.c + nout/√b.ri2[i], nout))  # assume b.p is orthogonal
+
     # For a given point x and equation of ellipsoid f(x) = 1, find t such that x₀ = x + t*∇f(x)
     # is on the ellipsoid.  Eventually this reduces to a quadratic equation for t.  The
     # following is evaluation of the quadratic formula in a numerically stable way.

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -23,7 +23,7 @@ Ellipsoid(b::Box{N,<:Any,L}, data::D=nothing) where {N,D,L} = Ellipsoid{N,D,L}(b
 Base.:(==)(b1::Ellipsoid, b2::Ellipsoid) = b1.c==b2.c && b1.ri2==b2.ri2 && b1.p==b2.p && b1.data==b2.data
 Base.hash(b::Ellipsoid, h::UInt) = hash(b.c, hash(b.ri2, hash(b.p, hash(b.data, hash(:Ellipsoid, h)))))
 
-Base.in(x::SVector{N}, b::Ellipsoid{N}) where {N} = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0  # change this using ⋅
+Base.in(x::SVector{N}, b::Ellipsoid{N}) where {N} = sum((b.p * (x - b.c)).^2 .* b.ri2) ≤ 1.0
 
 function surfpt_nearby(x::SVector{N}, b::Ellipsoid{N}) where {N}
     # For a given point x and equation of ellipsoid f(x) = 1, find t such that x₀ = x + t*∇f(x)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -16,7 +16,7 @@ Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h
 Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2,x - s.c) ≤ s.r^2
 
 function surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N}
-    nout = x==s.c ? SVector(ntuple(k -> k==N ? 1.0 : 0.0, Val{N})) :  # nout = e_N for x == s.c
+    nout = x==s.c ? SVector(ntuple(k -> k==1 ? 1.0 : 0.0, Val{N})) :  # nout = e₁ for x == s.c
                     normalize(x-s.c)
     return s.c+s.r*nout, nout
 end

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -14,5 +14,11 @@ Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.dat
 Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
 
 Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2,x - s.c) ≤ s.r^2
-surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N} = (nout = normalize(x - s.c); (s.c+s.r*nout, nout))
+
+function surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N}
+    nout = x==s.c ? SVector(ntuple(k -> k==N ? 1.0 : 0.0, Val{N})) :  # nout = e_N for x == s.c
+                    normalize(x-s.c)
+    return s.c+s.r*nout, nout
+end
+
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -14,5 +14,5 @@ Base.:(==)(s1::Sphere, s2::Sphere) = s1.c==s2.c && s1.r==s2.r && s1.data==s2.dat
 Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h))))
 
 Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2,x - s.c) ≤ s.r^2
-normal(x::SVector{N}, s::Sphere{N}) where {N} = normalize(x - s.c)
+surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N} = (nout = normalize(x - s.c); (s.c+s.r*nout, nout))
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using GeometryPrimitives, StaticArrays, Base.Test
 const rtol = Base.rtoldefault(Float64)
 const one⁻ = 1 - rtol  # slightly less than 1
 const one⁺ = 1 + rtol  # slightly greater than 1
+const one⁻⁻, one⁺⁺ = 0.9, 1.1
 
 Base.isapprox(a::Tuple, b::Tuple; kws...) = all(p -> isapprox(p...; kws...), zip(a,b))
 const rng = MersenneTwister(0) # test with reproducible pseudorandom numbers
@@ -55,6 +56,12 @@ end
             @test @inferred(ndims(s)) == 2
             @test @inferred([3,9] ∈ s)
             @test [3,9.1] ∉ s
+
+            @test all([@inferred(surfpt_nearby([3+ρ*sx*5,4],s))[1] ≈ [3+sx*5,4] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby([3,4+ρ*sy*5],s)[1] ≈ [3,4+sy*5] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([surfpt_nearby([3+ρ*sx*5/√2,4+ρ*sy*5/√2],s)[1] ≈ [3+sx*5/√2,4+sy*5/√2]
+                       for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1), sy = (-1,1)])
+
             @test @inferred(normal([-1,2],s)) == normalize([-1,2] - [3,4])
             @test @inferred(bounds(s)) == ([-2,-1],[8,9])
             @test checkbounds(s)
@@ -67,6 +74,12 @@ end
             @test hash(b) == hash(deepcopy(b))
             @test @inferred([0.3,-1.5] ∈ b)
             @test [0.3,-2.5] ∉ b
+
+            @test all([@inferred(surfpt_nearby([ρ*sx*1,0],b))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby([0,ρ*sy*2],b)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test surfpt_nearby([1.1,2.01], b)[1] ≈ [1.1,2]
+            @test surfpt_nearby([1.01,2.1], b)[1] ≈ [1,2.1]
+
             @test @inferred(normal([1.1,0],b)) == [1,0]
             @test normal([-1.1,0],b) == [-1,0]
             @test normal([1.1,2.01],b) == [0,1]
@@ -79,7 +92,7 @@ end
         @testset "Box, rotated" begin
             ax1, ax2 = [1,-1], [1,1]
             r1, r2 = 1, 2  # "radii"
-            br = Box([0,0], [2r1, 2r2], [ax1 ax2])
+            br = Box([0,0], [2r1, 2r2], [ax1 -ax2])  # use -ax2 to check signs of axes don't matter
 
             R = [normalize(ax1) normalize(ax2)]  # rotation matrix
 
@@ -90,6 +103,11 @@ end
 
             @test br == deepcopy(br)
             @test hash(br) == hash(deepcopy(br))
+
+            n1, n2 = normalize.((ax1, ax2))
+            @test all([@inferred(surfpt_nearby(ρ*s1*r1*n1,br))[1] ≈ s1*r1*n1 for ρ = (one⁻⁻,one⁺⁺), s1 = (-1,1)])
+            @test all([surfpt_nearby(ρ*s2*r2*n2,br)[1] ≈ s2*r2*n2 for ρ = (one⁻⁻,one⁺⁺), s2 = (-1,1)])
+
             @test @inferred(normal(R*[1.1r1, 0], br)) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
             @test normal(R*[0, 1.1r2], br) ≈ R*[0,1]
@@ -105,7 +123,15 @@ end
         @testset "Box, skewed" begin
             ax1, ax2 = normalize.(([1,-1], [0,1]))
             r1, r2 = 1, 1  # "radii"
-            bs = Box([0,0], [2r1, 2r2], [ax1 ax2])
+            bs = Box([0,0], [2r1, 2r2], [-ax1 ax2])  # use -ax1 to check signs of axes don't matter
+
+            @test bs == deepcopy(bs)
+            @test hash(bs) == hash(deepcopy(bs))
+
+            n1, n2 = normalize.(([1,0], [1,1]))
+            @test all([@inferred(surfpt_nearby(s2*(r2*ax2+∆ρ*n2),bs))[1] ≈ s2*r2*ax2 for ∆ρ = (-0.1,0.1), s2 = (-1,1)])
+            @test all([surfpt_nearby(s1*(r1*ax1+∆ρ*n1),bs)[1] ≈ s1*r1*ax1 for ∆ρ = (-0.1,0.1), s1 = (-1,1)])
+
             @test norm(normal([0,1], bs)) ≈ 1
 
             xmax = (r1*ax1+r2*ax2)[1]
@@ -120,9 +146,13 @@ end
             @test hash(e) == hash(deepcopy(e))
             @test @inferred([0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e)
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
-            @test @inferred(normal([1.1,0],e)) == [1,0]
-            @test normal([-1.1,0],e) == [-1,0]
-            @test normal([0,2.01],e) == [0,1]
+
+            @test all([@inferred(surfpt_nearby([ρ*sx*1,0],e))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby([0,ρ*sy*2],e)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+
+            @test @inferred(normal([1.1,0],e)) ≈ [1,0]
+            @test normal([-1.1,0],e) ≈ [-1,0]
+            @test normal([0,2.01],e) ≈ [0,1]
             @test @inferred(bounds(e)) == ([-1,-2],[1,2])
             @test checkbounds(e)
             @test checkbounds(Ellipsoid([0,0], [1,2], [1 1; 1 -1]))
@@ -135,7 +165,8 @@ end
 
         @testset "Ellipsoid, rotated" begin
             θ = π/3
-            er = Ellipsoid([0,0], [1,2], [cos(θ) sin(θ); sin(θ) -cos(θ)])
+            R = [cos(θ) sin(θ); sin(θ) -cos(θ)]
+            er = Ellipsoid([0,0], [1,2], R)
             bp = GeometryPrimitives.boundpts(er)
 
             bp1, bp2 = bp[:,1], bp[:,2]
@@ -145,6 +176,9 @@ end
             @test hash(er) == hash(deepcopy(er))
             @test (@inferred(one⁻ * bp1 ∈ er)) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
+
+            @test all([@inferred(surfpt_nearby(R*[ρ*sx*1,0],er))[1] ≈ R*[sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby(R*[0,ρ*sy*2],er)[1] ≈ R*[0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
 
             # Test the normal vector at the two bounding points are the x- and y-directions.
             @test @inferred(normal(bp1, er)) ≈ [1,0]
@@ -167,11 +201,36 @@ end
             @test @inferred([0.2,0.2,1] ∈ c)
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c
-            @test @inferred(normal([0.1,0.2,-1.3], c)) == [0,0,-1]
+
+            @test all([@inferred(surfpt_nearby([ρ*sx*0.3,0,0],c))[1] ≈ [sx*0.3,0,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby([0,ρ*sy*0.3,0],c)[1] ≈ [0,sy*0.3,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([surfpt_nearby([0,0,ρ*sz*1.1],c)[1] ≈ [0,0,sz*1.1] for ρ = (one⁻⁻,one⁺⁺), sz = (-1,1)])
+
+            @test @inferred(normal([0.1,0.2,-1.3], c)) == [0.1,0.2,0] / hypot(0.1,0.2)
+            @test @inferred(normal([0.1,0.2,-1.11], c)) == [0,0,-1]
             @test normal([0.31, 0, 0.3], c) == [1,0,0]
             @test @inferred(bounds(c)) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
+        end
+
+        @testset "Cylinder, rotated" begin
+            ax1 = normalize([1,0,1])
+            ax2 = normalize([1,0,-1])
+            cr = Cylinder([0,0,0], 0.3, -ax1, 2.2)  # use -ax1 to make sure sign of axis doesn't matter
+            @test cr == deepcopy(cr)
+            @test hash(cr) == hash(deepcopy(cr))
+
+            @test all([@inferred(surfpt_nearby(ρ*s3*1.1ax1,cr))[1] ≈ s3*1.1ax1 for ρ = (one⁻⁻,one⁺⁺), s3 = (-1,1)])
+            @test all([surfpt_nearby([0,ρ*sy*0.3,0],cr)[1] ≈ [0,sy*0.3,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([surfpt_nearby(ρ*sx*0.3*ax2,cr)[1] ≈ sx*0.3*ax2 for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+
+            @test all([@inferred(normal(ρ*s3*1.1ax1,cr)) ≈ s3*ax1 for ρ = (one⁻⁻,one⁺⁺), s3 = (-1,1)])
+            @test all([normal([0,ρ*sy*0.3,0],cr) ≈ sy*[0,1,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([normal(ρ*sx*0.3*ax2,cr) ≈ sx*ax2 for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+
+            @test @inferred(bounds(cr)) ≈ (-[(1.1+0.3)/√2,0.3,(1.1+0.3)/√2], [(1.1+0.3)/√2,0.3,(1.1+0.3)/√2])
+            @test checkbounds(cr)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,10 +57,13 @@ end
             @test @inferred([3,9] ∈ s)
             @test [3,9.1] ∉ s
 
-            @test all([@inferred(surfpt_nearby([3+ρ*sx*5,4],s))[1] ≈ [3+sx*5,4] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
-            @test all([surfpt_nearby([3,4+ρ*sy*5],s)[1] ≈ [3,4+sy*5] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test @inferred(surfpt_nearby([3,4],s)) == ([3,9],[0,1])  # handle point at center properly
+            @test all([surfpt_nearby([3+ρ*sx*5,4],s)[1] ≈ [3+sx*5,4] for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby([3,4+ρ*sy*5],s)[1] ≈ [3,4+sy*5] for ρ = (one⁻⁻,1,one⁺⁺), sy = (-1,1)])
             @test all([surfpt_nearby([3+ρ*sx*5/√2,4+ρ*sy*5/√2],s)[1] ≈ [3+sx*5/√2,4+sy*5/√2]
                        for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1), sy = (-1,1)])
+           @test all([(p = [3+sx*5,4]; surfpt_nearby(p,s) ≈ (p,[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
+           @test all([(p = [3,4+sy*5]; surfpt_nearby(p,s) ≈ (p,[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
 
             @test @inferred(normal([-1,2],s)) == normalize([-1,2] - [3,4])
             @test @inferred(bounds(s)) == ([-2,-1],[8,9])
@@ -77,6 +80,8 @@ end
 
             @test all([@inferred(surfpt_nearby([ρ*sx*1,0],b))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*2],b)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([(p = [sx*1,0]; surfpt_nearby(p,b) ≈ (p,[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
+            @test all([(p = [0,sy*2]; surfpt_nearby(p,b) ≈ (p,[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
             @test surfpt_nearby([1.1,2.01], b)[1] ≈ [1.1,2]
             @test surfpt_nearby([1.01,2.1], b)[1] ≈ [1,2.1]
 
@@ -107,6 +112,8 @@ end
             n1, n2 = normalize.((ax1, ax2))
             @test all([@inferred(surfpt_nearby(ρ*s1*r1*n1,br))[1] ≈ s1*r1*n1 for ρ = (one⁻⁻,one⁺⁺), s1 = (-1,1)])
             @test all([surfpt_nearby(ρ*s2*r2*n2,br)[1] ≈ s2*r2*n2 for ρ = (one⁻⁻,one⁺⁺), s2 = (-1,1)])
+            @test all([(p = s1*r1*n1; surfpt_nearby(p,br) ≈ (p,s1*n1)) for s1 = (-1,1)])  # handle point on boundary properly
+            @test all([(p = s2*r2*n2; surfpt_nearby(p,br) ≈ (p,s2*n2)) for s2 = (-1,1)])  # handle point on boundary properly
 
             @test @inferred(normal(R*[1.1r1, 0], br)) ≈ R*[1,0]
             @test normal(R*[-1.1r1, 0], br) ≈ R*[-1,0]
@@ -131,6 +138,8 @@ end
             n1, n2 = normalize.(([1,0], [1,1]))
             @test all([@inferred(surfpt_nearby(s2*(r2*ax2+∆ρ*n2),bs))[1] ≈ s2*r2*ax2 for ∆ρ = (-0.1,0.1), s2 = (-1,1)])
             @test all([surfpt_nearby(s1*(r1*ax1+∆ρ*n1),bs)[1] ≈ s1*r1*ax1 for ∆ρ = (-0.1,0.1), s1 = (-1,1)])
+            @test all([(p = s1*r1*ax1; surfpt_nearby(p,bs) ≈ (p,s1*n1)) for s1 = (-1,1)])  # handle point on boundary properly
+            @test all([(p = s2*r2*ax2; surfpt_nearby(p,bs) ≈ (p,s2*n2)) for s2 = (-1,1)])  # handle point on boundary properly
 
             @test norm(normal([0,1], bs)) ≈ 1
 
@@ -149,6 +158,8 @@ end
 
             @test all([@inferred(surfpt_nearby([ρ*sx*1,0],e))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*2],e)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([(p = [sx*1,0]; surfpt_nearby(p,e) ≈ (p,[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
+            @test all([(p = [0,sy*2]; surfpt_nearby(p,e) ≈ (p,[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
 
             @test @inferred(normal([1.1,0],e)) ≈ [1,0]
             @test normal([-1.1,0],e) ≈ [-1,0]
@@ -179,6 +190,8 @@ end
 
             @test all([@inferred(surfpt_nearby(R*[ρ*sx*1,0],er))[1] ≈ R*[sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby(R*[0,ρ*sy*2],er)[1] ≈ R*[0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([(p = R*[sx*1,0]; surfpt_nearby(p,er) ≈ (p,R*[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
+            @test all([(p = R*[0,sy*2]; surfpt_nearby(p,er) ≈ (p,R*[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
 
             # Test the normal vector at the two bounding points are the x- and y-directions.
             @test @inferred(normal(bp1, er)) ≈ [1,0]
@@ -202,9 +215,12 @@ end
             @test SVector(0.2,0.2,1.2) ∉ c
             @test [0.2,0.25,1] ∉ c
 
-            @test all([@inferred(surfpt_nearby([ρ*sx*0.3,0,0],c))[1] ≈ [sx*0.3,0,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test @inferred(surfpt_nearby([0,0,0],c)) == ([0,0,1.1],[0,0,1])  # handle point at center properly
+            @test all([surfpt_nearby([ρ*sx*0.3,0,0],c)[1] ≈ [sx*0.3,0,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*0.3,0],c)[1] ≈ [0,sy*0.3,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
             @test all([surfpt_nearby([0,0,ρ*sz*1.1],c)[1] ≈ [0,0,sz*1.1] for ρ = (one⁻⁻,one⁺⁺), sz = (-1,1)])
+            @test all([(p = [0,sy*0.3,0]; surfpt_nearby(p,c) ≈ (p,[0,sy,0])) for sy = (-1,1)])  # handle point on boundary properly
+            @test all([(p = [0,0,sz*1.1]; surfpt_nearby(p,c) ≈ (p,[0,0,sz])) for sz = (-1,1)])  # handle point on boundary properly
 
             @test @inferred(normal([0.1,0.2,-1.3], c)) == [0.1,0.2,0] / hypot(0.1,0.2)
             @test @inferred(normal([0.1,0.2,-1.11], c)) == [0,0,-1]
@@ -221,9 +237,13 @@ end
             @test cr == deepcopy(cr)
             @test hash(cr) == hash(deepcopy(cr))
 
-            @test all([@inferred(surfpt_nearby(ρ*s3*1.1ax1,cr))[1] ≈ s3*1.1ax1 for ρ = (one⁻⁻,one⁺⁺), s3 = (-1,1)])
+            @test @inferred(surfpt_nearby([0,0,0],cr)) ≈ (-1.1ax1,-ax1)  # handle point at center properly
+            @test all([(p = s1*1.1*ax1; surfpt_nearby(p,cr) ≈ (p,s1*ax1)) for s1 = (-1,1)])  # handle point on axis properly
+            @test all([surfpt_nearby(ρ*s3*1.1ax1,cr)[1] ≈ s3*1.1ax1 for ρ = (one⁻⁻,one⁺⁺), s3 = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*0.3,0],cr)[1] ≈ [0,sy*0.3,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
             @test all([surfpt_nearby(ρ*sx*0.3*ax2,cr)[1] ≈ sx*0.3*ax2 for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([(p = [0,sy*0.3,0]; surfpt_nearby(p,cr) ≈ (p,[0,sy,0])) for sy = (-1,1)])  # handle point on boundary properly
+            @test all([(p = sx*0.3*ax2; surfpt_nearby(p,cr) ≈ (p, sx*ax2)) for sx = (-1,1)])  # handle point on boundary properly
 
             @test all([@inferred(normal(ρ*s3*1.1ax1,cr)) ≈ s3*ax1 for ρ = (one⁻⁻,one⁺⁺), s3 = (-1,1)])
             @test all([normal([0,ρ*sy*0.3,0],cr) ≈ sy*[0,1,0] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ end
             @test @inferred([3,9] ∈ s)
             @test [3,9.1] ∉ s
 
-            @test @inferred(surfpt_nearby([3,4],s)) == ([3,9],[0,1])  # handle point at center properly
+            @test @inferred(surfpt_nearby([3,4],s)) == ([8,4],[1,0])  # handle point at center properly
             @test all([surfpt_nearby([3+ρ*sx*5,4],s)[1] ≈ [3+sx*5,4] for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([3,4+ρ*sy*5],s)[1] ≈ [3,4+sy*5] for ρ = (one⁻⁻,1,one⁺⁺), sy = (-1,1)])
             @test all([surfpt_nearby([3+ρ*sx*5/√2,4+ρ*sy*5/√2],s)[1] ≈ [3+sx*5/√2,4+sy*5/√2]
@@ -78,7 +78,8 @@ end
             @test @inferred([0.3,-1.5] ∈ b)
             @test [0.3,-2.5] ∉ b
 
-            @test all([@inferred(surfpt_nearby([ρ*sx*1,0],b))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test @inferred(surfpt_nearby([0,0],b)) == ([1,0],[1,0])  # handle point at center properly
+            @test all([surfpt_nearby([ρ*sx*1,0],b)[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*2],b)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
             @test all([(p = [sx*1,0]; surfpt_nearby(p,b) ≈ (p,[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
             @test all([(p = [0,sy*2]; surfpt_nearby(p,b) ≈ (p,[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
@@ -110,7 +111,8 @@ end
             @test hash(br) == hash(deepcopy(br))
 
             n1, n2 = normalize.((ax1, ax2))
-            @test all([@inferred(surfpt_nearby(ρ*s1*r1*n1,br))[1] ≈ s1*r1*n1 for ρ = (one⁻⁻,one⁺⁺), s1 = (-1,1)])
+            @test @inferred(surfpt_nearby([0,0],br)) ≈ (n1,n1)  # handle point at center properly
+            @test all([surfpt_nearby(ρ*s1*r1*n1,br)[1] ≈ s1*r1*n1 for ρ = (one⁻⁻,one⁺⁺), s1 = (-1,1)])
             @test all([surfpt_nearby(ρ*s2*r2*n2,br)[1] ≈ s2*r2*n2 for ρ = (one⁻⁻,one⁺⁺), s2 = (-1,1)])
             @test all([(p = s1*r1*n1; surfpt_nearby(p,br) ≈ (p,s1*n1)) for s1 = (-1,1)])  # handle point on boundary properly
             @test all([(p = s2*r2*n2; surfpt_nearby(p,br) ≈ (p,s2*n2)) for s2 = (-1,1)])  # handle point on boundary properly
@@ -136,7 +138,9 @@ end
             @test hash(bs) == hash(deepcopy(bs))
 
             n1, n2 = normalize.(([1,0], [1,1]))
-            @test all([@inferred(surfpt_nearby(s2*(r2*ax2+∆ρ*n2),bs))[1] ≈ s2*r2*ax2 for ∆ρ = (-0.1,0.1), s2 = (-1,1)])
+            cosθ = (-ax1) ⋅ (-n1)
+            @test @inferred(surfpt_nearby([0,0],bs)) ≈ (-cosθ*n1,-n1)  # handle point at center properly
+            @test all([surfpt_nearby(s2*(r2*ax2+∆ρ*n2),bs)[1] ≈ s2*r2*ax2 for ∆ρ = (-0.1,0.1), s2 = (-1,1)])
             @test all([surfpt_nearby(s1*(r1*ax1+∆ρ*n1),bs)[1] ≈ s1*r1*ax1 for ∆ρ = (-0.1,0.1), s1 = (-1,1)])
             @test all([(p = s1*r1*ax1; surfpt_nearby(p,bs) ≈ (p,s1*n1)) for s1 = (-1,1)])  # handle point on boundary properly
             @test all([(p = s2*r2*ax2; surfpt_nearby(p,bs) ≈ (p,s2*n2)) for s2 = (-1,1)])  # handle point on boundary properly
@@ -156,7 +160,8 @@ end
             @test @inferred([0.3,2*sqrt(1 - 0.3^2)-0.01] ∈ e)
             @test [0.3,2*sqrt(1 - 0.3^2)+0.01] ∉ e
 
-            @test all([@inferred(surfpt_nearby([ρ*sx*1,0],e))[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test @inferred(surfpt_nearby([0,0],e)) ≈ ([1,0], [1,0])  # handle point at center properly
+            @test all([surfpt_nearby([ρ*sx*1,0],e)[1] ≈ [sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
             @test all([surfpt_nearby([0,ρ*sy*2],e)[1] ≈ [0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
             @test all([(p = [sx*1,0]; surfpt_nearby(p,e) ≈ (p,[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
             @test all([(p = [0,sy*2]; surfpt_nearby(p,e) ≈ (p,[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
@@ -177,7 +182,7 @@ end
         @testset "Ellipsoid, rotated" begin
             θ = π/3
             R = [cos(θ) sin(θ); sin(θ) -cos(θ)]
-            er = Ellipsoid([0,0], [1,2], R)
+            er = Ellipsoid([0,0], [2,3], R)
             bp = GeometryPrimitives.boundpts(er)
 
             bp1, bp2 = bp[:,1], bp[:,2]
@@ -188,10 +193,11 @@ end
             @test (@inferred(one⁻ * bp1 ∈ er)) && (one⁻ * bp2 ∈ er)
             @test (one⁺ * bp1 ∉ er) && (one⁺ * bp2 ∉ er)
 
-            @test all([@inferred(surfpt_nearby(R*[ρ*sx*1,0],er))[1] ≈ R*[sx*1,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
-            @test all([surfpt_nearby(R*[0,ρ*sy*2],er)[1] ≈ R*[0,sy*2] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
-            @test all([(p = R*[sx*1,0]; surfpt_nearby(p,er) ≈ (p,R*[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
-            @test all([(p = R*[0,sy*2]; surfpt_nearby(p,er) ≈ (p,R*[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
+            @test @inferred(surfpt_nearby([0,0],er)) ≈ (2*R[:,1], R[:,1])  # handle point at center properly
+            @test all([surfpt_nearby(R*[ρ*sx*2,0],er)[1] ≈ R*[sx*2,0] for ρ = (one⁻⁻,one⁺⁺), sx = (-1,1)])
+            @test all([surfpt_nearby(R*[0,ρ*sy*3],er)[1] ≈ R*[0,sy*3] for ρ = (one⁻⁻,one⁺⁺), sy = (-1,1)])
+            @test all([(p = R*[sx*2,0]; surfpt_nearby(p,er) ≈ (p,R*[sx,0])) for sx = (-1,1)])  # handle point on boundary properly
+            @test all([(p = R*[0,sy*3]; surfpt_nearby(p,er) ≈ (p,R*[0,sy])) for sy = (-1,1)])  # handle point on boundary properly
 
             # Test the normal vector at the two bounding points are the x- and y-directions.
             @test @inferred(normal(bp1, er)) ≈ [1,0]
@@ -201,7 +207,7 @@ end
             @test @inferred(bounds(er)) == ([-xmax, -ymax], [xmax, ymax])
             @test checkbounds(er)
 
-            br = Box([0,0], [2,4], [cos(θ) sin(θ); sin(θ) -cos(θ)])
+            br = Box([0,0], 2*[2,3], R)
             ebr = Ellipsoid(br)
             @test er == ebr
             @test hash(er) == hash(ebr)


### PR DESCRIPTION
This PR adds the `surfpt_nearby` function, which returns a surface point nearby a given point and the outward normal at the surface point.

A few more details:
- `normal` is now implemented using `surfpt_nearby`.  This is because the calculation of the nearby surface point almost always requires the calculation of the outward normal direction.  Therefore, if one would like to calculate both the nearby surface point and outward normal, s/he is recommended to call `surfpt_nearby` once, instead of subsequently calling `normal`.
- `Cylinder` now calculates the outward normal differently than before.  Previously it returned the axis directions only if the point of evaluation is above the top base or below the bottom base.  (In other words, it didn't return the axis directions if the point is inside the cylinder.)  Now, it returns the axis directions even if the point of evaluation is between the top and bottom bases, if the point is closer to the bases than the side.  (This behavior is similar to `Box`'s.)  This change is to ensure that the nearby surface point is along the normal direction from the given point.