### PR TITLE
Prevent infinite recursion in KDTree construction (fixes #21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,11 @@ environment:
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
+matrix:
+  allow_failures:
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
 branches:
   only:
     - master

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -60,7 +60,7 @@ function KDTree(s::AbstractVector{S}) where {K,S<:Shape{K}}
     end
 
     # don't bother subdividing if it doesn't reduce the # of shapes much
-    4*min(nl,nr) > 3*length(s) && return KDTree{K,S}(s)
+    4*max(nl,nr) > 3*length(s) && return KDTree{K,S}(s)
 
     # create the arrays of shapes in each subtree
     sl = Array{S}(nl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,12 +262,18 @@ end
     end
 
     @testset "KDTree" begin
+        s = [Sphere([i,0], 1) for i in 0:10]
+        s0 = Sphere([0,0], 1)
+        s = [s0, s0, s0, s0, s...]
+        @test_nowarn KDTree(s)  # must not generate StackOverflowError
+
         s = Shape{2,4}[Sphere([i,0], 1, i) for i in 0:20]
         kd = KDTree(s)
-        @test GeometryPrimitives.depth(kd) == 4
+        @test GeometryPrimitives.depth(kd) == 3
         @test get(findin([10.1,0], kd)).data == 10
         @test isnull(findin([10.1,1], kd))
         @test checktree(kd, s)
+
         s = Shape{3,9}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
         @test checktree(KDTree(s), s)
         s = Shape{3,9}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,7 +262,7 @@ end
     end
 
     @testset "KDTree" begin
-        s = [Sphere([i,0], 1) for i in 0:10]
+        s = [Sphere([i,0], 1) for i in 2:4]
         s0 = Sphere([0,0], 1)
         s = [s0, s0, s0, s0, s...]
         @test_nowarn KDTree(s)  # must not generate StackOverflowError


### PR DESCRIPTION
This PR fixes #21 by giving up branching in `KDTree` construction when either one of the left and right child trees has a similar number of shapes as the parent tree.

This PR also adds a test case where infinite recursion could happen in the original code.