### PR TITLE
Take symmetry more seriously in surfpt_nearby around sharp corners

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -42,9 +42,9 @@ function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     d = b.p * (x - b.c)
     n = n .* copysign.(1.0,d)  # operation returns SMatrix (reason for leaving n untransposed)
     absd = abs.(d)
-    onbound = abs.(b.r-absd) .≤ Base.rtoldefault(Float64) * b.r  # basically b.r .≈ absd but faster
+    onbound = abs.(b.r.-absd) .≤ Base.rtoldefault(Float64) .* b.r  # basically b.r .≈ absd but faster
     isout = (b.r.<absd) .| onbound
-    ∆ = (b.r - absd) .* cosθ
+    ∆ = (b.r .- absd) .* cosθ
     if count(isout) == 0  # x strictly inside box
         l∆x, i = findmin(∆)
         nout = n[i,:]

--- a/src/box.jl
+++ b/src/box.jl
@@ -30,14 +30,32 @@ function Base.in(x::SVector{N}, b::Box{N}) where {N}
 end
 
 function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
-    d = b.p * (x - b.c)
-    _m, i = findmin(abs.(abs.(d) - b.r))
-    nout = normalize(b.p[i,:])  # direction normal; b.p[i,:] is non-unit for non-rectangular box
-    cosθ = nout ⋅ inv(b.p)[:,i]  # θ: angle between nout and ith axis
-    l∆x = (b.r[i] - abs(d[i])) * cosθ  # distance between surface point and x
-    d[i] < 0 && (nout = -nout)
+    ax = inv(b.p)  # axes
+    n = (b.p ./ sqrt.(sum(abs2,b.p,Val{2})[:,1]))  # rows are direction normals; do not take transpose
 
-    return x + l∆x*nout, nout
+    # Below, θ[i], the angle between ax[:,i] and n[i,:], is always acute, because the
+    # diagonal entries of ax * b.p are positive (= 1).
+    cosθ = sum(ax.*n', Val{1})[1,:]
+    # cosθ = diag(n*ax)  # faster than SVector(ntuple(i -> ax[:,i]⋅n[i,:], Val{N}))
+    # assert(all(cosθ .≥ 0))
+
+    d = b.p * (x - b.c)
+    n = n .* copysign.(1.0,d)  # operation returns SMatrix (reason for leaving n untransposed)
+    absd = abs.(d)
+    onbound = abs.(b.r-absd) .≤ Base.rtoldefault(Float64) * b.r  # basically b.r .≈ absd but faster
+    isout = (b.r.<absd) .| onbound
+    ∆ = (b.r - absd) .* cosθ
+    if count(isout) == 0  # x strictly inside box
+        l∆x, i = findmin(∆)
+        nout = n[i,:]
+        ∆x = l∆x * nout
+    else  # x outside box or on boundary in one or multiple directions
+        ∆x = n' * (∆ .* isout)  # project only in isout directions
+        nout = all(.!isout .| onbound) ? n'*onbound : -∆x  # "if onbound in projected directions"
+        nout = normalize(nout)
+    end
+
+    return x+∆x, nout
 end
 
 signmatrix(b::Shape{1}) = SMatrix{1,2}(1,-1)
@@ -50,6 +68,8 @@ function bounds(b::Box)
     # is not SVector.  Then, we cannot use maximum(..., Val{2}), which is type-stable
     # for SMatrix.  A workaround is to calculate inv(b.p') .* b.r and take transpose.
     A = (inv(b.p') .* b.r)'  # SMatrix
+    # Use this after StaticArrays issue 242 is fixed:
+    #    A = inv(b.p) .* b.r'
 
     m = maximum(A * signmatrix(b), Val{2})[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -33,8 +33,8 @@ function surfpt_nearby(x::SVector{N}, s::Cylinder{N}) where {N}
     pout = copysign(1.0,p) * s.a
     qout = lq≠0 ? q/lq : @SVector(zeros(N))  # qout is used only when lq ≠ 0 below
 
-    onbndp = abs(lp.-s.h2) .≤ Base.rtoldefault(Float64) .* s.h2
-    onbndq = abs(lq.-s.r) .≤ Base.rtoldefault(Float64) .* s.r
+    onbndp = abs(lp.-s.h2) .≤ Base.rtoldefault(Float64) * s.h2
+    onbndq = abs(lq.-s.r) .≤ Base.rtoldefault(Float64) * s.r
     isoutp = (s.h2<lp) || onbndp
     isoutq = (s.r<lq) || onbndq
     ∆p, ∆q = s.h2-lp, s.r-lq

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -33,8 +33,8 @@ function surfpt_nearby(x::SVector{N}, s::Cylinder{N}) where {N}
     pout = copysign(1.0,p) * s.a
     qout = lq≠0 ? q/lq : @SVector(zeros(N))  # qout is used only when lq ≠ 0 below
 
-    onbndp = abs(lp-s.h2) ≤ Base.rtoldefault(Float64) * s.h2
-    onbndq = abs(lq-s.r) ≤ Base.rtoldefault(Float64) * s.r
+    onbndp = abs(lp.-s.h2) .≤ Base.rtoldefault(Float64) .* s.h2
+    onbndq = abs(lq.-s.r) .≤ Base.rtoldefault(Float64) .* s.r
     isoutp = (s.h2<lp) || onbndp
     isoutq = (s.r<lq) || onbndq
     ∆p, ∆q = s.h2-lp, s.r-lq


### PR DESCRIPTION
With this PR, the normal directions produced by `surpt_nearby` are more symmetric around sharpf corners of `Box` and `Cylinder`.  For example, for a unit square around the origin (with corners at `[±0.5, ±0.5]`), the normal direction obtained at `[0.51, 0.51]` is in the `[1, 1]` direction, whereas the normal direction obtained at `[-0.51, 0.51]` is in the `[-1, 1]` direction.  Previously this was not necessarily the case.

This change helps generating a symmetric material parameter distribution after subpixel smoothing of electromagnetic properties on a finite-difference grid. 