### PR TITLE
Prevent infinite recursion in KDTree construction

### DIFF
--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -60,7 +60,7 @@ function KDTree(s::AbstractVector{S}) where {K,S<:Shape{K}}
     end
 
     # don't bother subdividing if it doesn't reduce the # of shapes much
-    4*max(nl,nr) > 3*length(s) && return KDTree{K,S}(s)
+    4*max(nl,nr) > 3*length(s) && return KDTree{K,S}(s)  # use max instead of min to avoid infinite recursion
 
     # create the arrays of shapes in each subtree
     sl = Array{S}(nl)

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -60,7 +60,7 @@ function KDTree(s::AbstractVector{S}) where {K,S<:Shape{K}}
     end
 
     # don't bother subdividing if it doesn't reduce the # of shapes much
-    4*min(nl,nr) > 3*length(s) && return KDTree{K,S}(s)
+    4*max(nl,nr) > 3*length(s) && return KDTree{K,S}(s)
 
     # create the arrays of shapes in each subtree
     sl = Array{S}(nl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,12 +262,18 @@ end
     end
 
     @testset "KDTree" begin
+        s = [Sphere([i,0], 1) for i in 0:10]
+        s0 = Sphere([0,0], 1)
+        s = [s0, s0, s0, s0, s...]
+        @test_nowarn KDTree(s)  # make sure segmentation fault caused by StackOverflowError does not occur due to infinite recursion
+
         s = Shape{2,4}[Sphere([i,0], 1, i) for i in 0:20]
         kd = KDTree(s)
-        @test GeometryPrimitives.depth(kd) == 4
+        @test GeometryPrimitives.depth(kd) == 3
         @test get(findin([10.1,0], kd)).data == 10
         @test isnull(findin([10.1,1], kd))
         @test checktree(kd, s)
+
         s = Shape{3,9}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
         @test checktree(KDTree(s), s)
         s = Shape{3,9}[Sphere(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]


### PR DESCRIPTION
This PR resolves the issue of `KDTree` constructor falling into infinite recursion.  

In the original code, `KDTree` constructor stops creating the left and right subtrees when the smaller subtree is not sufficiently small compared to the parent tree.  However, there are cases where the smaller subtree is sufficiently small while the other subtree is the same as the parent tree.  In such cases, even though the smaller subtree is sufficiently small compared to the parent tree and therefore recursive subdivision ensues, the larger subtree remains the same as the parent tree, and hence infinite recursion occurs.

For example, this occurs when between a half and 3/4 of the shapes in the parent tree are co-centered and the remaining shapes are to the right of the co-center.  Then, the median of the shape centers are at the co-center, so the left subtree is composed of the co-centered shapes and therefore its size is less than 3/4 of the parent tree, thereby satisfying the condition to ensue subsequent subdivision.  However, because the median is at the co-center, the right subtree remains the same as the parent tree.

To prevent this from happening, this PR ensues subdivision when *both* the left and right subtrees are sufficiently smaller than the parent tree.