### PR TITLE
Add comments on nontrivial type instability

### DIFF
--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -5,18 +5,20 @@ export Shape, surfpt_nearby, normal, bounds
 abstract type Shape{N,L,D} end # a solid geometric shape in N dimensions (L = N*N is needed in some shapes, e.g., Box)
 
 Base.ndims(o::Shape{N}) where {N} = N
-Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
 
+# The following functions return Any due to the limitations of Julia's dispatch system.
+# Therefore, always call them with type assertions.  See
+# https://discourse.julialang.org/t/extending-base-in-type-stably/5341/12
+# https://github.com/JuliaLang/julia/issues/23210
+Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
 surfpt_nearby(x::AbstractVector, o::Shape{N}) where {N} = surfpt_nearby(SVector{N}(x), o)
 normal(x::AbstractVector, o::Shape) = surfpt_nearby(x, o)[2]
 
-include("sphere.jl")
 include("box.jl")
-include("ellipsoid.jl")
 include("cylinder.jl")
-
+include("ellipsoid.jl")
+include("sphere.jl")
 include("kdtree.jl")
-
 include("vxlcut.jl")
 
 end # module


### PR DESCRIPTION
This PR concerns type instability mentioned in #19.  Through the discussions in a Julia issue and discourse, it turned out that the best way to avoid this type instability is to use type assertion.  This PR adds comments that point the users to the relevant discussions and recommend using type assertion on the return values.