### PR TITLE
Improve StaticArrays usage

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -58,9 +58,9 @@ function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     return x+∆x, nout
 end
 
-signmatrix(b::Shape{1}) = SMatrix{1,2}(1,-1)
-signmatrix(b::Shape{2}) = SMatrix{2,4}(1,1, -1,1, 1,-1, -1,-1)
-signmatrix(b::Shape{3}) = SMatrix{3,8}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1, -1,-1,1, -1,1,-1, 1,-1,-1, -1,-1,-1)
+signmatrix(b::Box{1}) = SMatrix{1,1}(1)
+signmatrix(b::Box{2}) = SMatrix{2,2}(1,1, -1,1)
+signmatrix(b::Box{3}) = SMatrix{3,4}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1)
 
 function bounds(b::Box)
     # Below, inv(b.p) .* b.r' would have been conceptually better because its columns
@@ -71,6 +71,6 @@ function bounds(b::Box)
     # Use this after StaticArrays issue 242 is fixed:
     #    A = inv(b.p) .* b.r'
 
-    m = maximum(A * signmatrix(b), Val{2})[:,1] # extrema of all 2^N corners of the box
+    m = maximum(abs.(A * signmatrix(b)), Val{2})[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)
 end

--- a/src/box.jl
+++ b/src/box.jl
@@ -11,9 +11,7 @@ end
 Box(c::SVector{N}, d::SVector{N},
     axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
     data::D=nothing) where {N,L,D} =
-    Box{N,L,D}(c, 0.5d, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
-# Use this after StaticArrays issue 242 is fixed:
-#    Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
+    Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
 
 Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
     (N = length(c); Box(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
@@ -63,14 +61,7 @@ signmatrix(b::Box{2}) = SMatrix{2,2}(1,1, -1,1)
 signmatrix(b::Box{3}) = SMatrix{3,4}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1)
 
 function bounds(b::Box)
-    # Below, inv(b.p) .* b.r' would have been conceptually better because its columns
-    # are scaled axes vectors.  However, then the result is not SMatrix because b.r'
-    # is not SVector.  Then, we cannot use maximum(..., Val{2}), which is type-stable
-    # for SMatrix.  A workaround is to calculate inv(b.p') .* b.r and take transpose.
-    A = (inv(b.p') .* b.r)'  # SMatrix
-    # Use this after StaticArrays issue 242 is fixed:
-    #    A = inv(b.p) .* b.r'
-
+    A = inv(b.p) .* b.r'
     m = maximum(abs.(A * signmatrix(b)), Val{2})[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -11,9 +11,7 @@ end
 Ellipsoid(c::SVector{N}, r::SVector{N},
           axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
           data::D=nothing) where {N,L,D} =
-    Ellipsoid{N,L,D}(c, float.(r).^-2, inv((axes' ./ sqrt.(sum(abs2,axes,Val{1}))[1,:])'), data)
-# Use this after StaticArrays issue 242 is fixed:
-#    Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
+    Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
 
 Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=eye(length(c)), data=nothing) =
     (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(r), SMatrix{N,N}(axes), data))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,8 +103,8 @@ end
 
             Cin = R * (GeometryPrimitives.signmatrix(br) .* (one⁻ .* [r1,r2]))  # around corners, inside
             Cout = R * (GeometryPrimitives.signmatrix(br) .* (one⁺ .* [r1,r2]))  # around corners, outside
-            for j = 1:4; @test Cin[:,j] ∈ br; end
-            for j = 1:4; @test Cout[:,j] ∉ br; end
+            for j = 1:2; @test Cin[:,j] ∈ br; end
+            for j = 1:2; @test Cout[:,j] ∉ br; end
 
             @test br == deepcopy(br)
             @test hash(br) == hash(deepcopy(br))


### PR DESCRIPTION
This PR makes a few improvements on the usage of `StaticArrays`:

- Halve the size of `signmatrix` to work around `StaticArrays` [Issue #384](https://github.com/JuliaArrays/StaticArrays.jl/issues/384).
- Simplify some expressions by taking advantage of `StaticArrays` [PR #274](https://github.com/JuliaArrays/StaticArrays.jl/pull/274) on `broadcast`.