### PR TITLE
Add a function to generate a periodic array of Shape

### DIFF
--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -1,6 +1,6 @@
 module GeometryPrimitives
 using Compat, StaticArrays
-export Shape, surfpt_nearby, normal, bounds
+export Shape, surfpt_nearby, normal, bounds, translate, periodize
 
 abstract type Shape{N,L,D} end # a solid geometric shape in N dimensions (L = N*N is needed in some shapes, e.g., Box)
 
@@ -13,6 +13,8 @@ Base.ndims(o::Shape{N}) where {N} = N
 Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
 surfpt_nearby(x::AbstractVector, o::Shape{N}) where {N} = surfpt_nearby(SVector{N}(x), o)
 normal(x::AbstractVector, o::Shape) = surfpt_nearby(x, o)[2]
+translate(o::Shape{N}, ∆::AbstractVector) where {N} = translate(o, SVector{N}(∆))
+periodize(o::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(o, SMatrix{N,N}(A), ∆range)
 
 include("box.jl")
 include("cylinder.jl")

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -1,6 +1,6 @@
 module GeometryPrimitives
 using Compat, StaticArrays
-export Shape, surfpt_nearby, normal, bounds, translate, periodize
+export Shape, surfpt_nearby, normal, bounds, translate
 
 abstract type Shape{N,L,D} end # a solid geometric shape in N dimensions (L = N*N is needed in some shapes, e.g., Box)
 
@@ -14,7 +14,6 @@ Base.in(x::AbstractVector, o::Shape{N}) where {N} = SVector{N}(x) in o
 surfpt_nearby(x::AbstractVector, o::Shape{N}) where {N} = surfpt_nearby(SVector{N}(x), o)
 normal(x::AbstractVector, o::Shape) = surfpt_nearby(x, o)[2]
 translate(o::Shape{N}, ∆::AbstractVector) where {N} = translate(o, SVector{N}(∆))
-periodize(o::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(o, SMatrix{N,N}(A), ∆range)
 
 include("box.jl")
 include("cylinder.jl")

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -20,6 +20,7 @@ include("box.jl")
 include("cylinder.jl")
 include("ellipsoid.jl")
 include("sphere.jl")
+include("periodize.jl")
 include("kdtree.jl")
 include("vxlcut.jl")
 

--- a/src/box.jl
+++ b/src/box.jl
@@ -56,6 +56,8 @@ function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     return x+∆x, nout
 end
 
+translate(b::Box{N,L,D}, ∆::SVector{N}) where {N,L,D} = Box{N,L,D}(b.c+∆, b.r, b.p, b.data)
+
 signmatrix(b::Box{1}) = SMatrix{1,1}(1)
 signmatrix(b::Box{2}) = SMatrix{2,2}(1,1, -1,1)
 signmatrix(b::Box{3}) = SMatrix{3,4}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1)

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -49,6 +49,8 @@ function surfpt_nearby(x::SVector{N}, s::Cylinder{N}) where {N}
     return x+∆x, nout
 end
 
+translate(s::Cylinder{N,L,D}, ∆::SVector{N}) where {N,L,D} = Cylinder{N,L,D}(s.c+∆, s.r, s.a, s.h2, s.data)
+
 const rotate2 = @SMatrix [0.0 1.0; -1.0 0.0] # 2x2 90° rotation matrix
 
 function endcircles(s::Cylinder{2})

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -55,6 +55,8 @@ function surfpt_nearby(x::SVector{N}, b::Ellipsoid{N}) where {N}
     return x₀, nout
 end
 
+translate(b::Ellipsoid{N,L,D}, ∆::SVector{N}) where {N,L,D} = Ellipsoid{N,L,D}(b.c+∆, b.ri2, b.p, b.data)
+
 function boundpts(b::Ellipsoid{N}) where {N}
     # Return the points tangential to the bounding box.
     # For N = 3, it returns three points at which the direction normals are +x, +y, +z

--- a/src/periodize.jl
+++ b/src/periodize.jl
@@ -1,12 +1,11 @@
 export periodize
 
-periodize(o::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(o, SMatrix{N,N}(A), ∆range)
+periodize(shp::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(shp, SMatrix{N,N}(A), ∆range)
 
-
-function periodize(o::S,  # shape to periodize
-                   A::SMatrix{N,N,<:Real,L},  # columns: primitive vectors of Bravais lattice
-                   ∆range::Shape{N,L}  # range of translation vectors; boundaries included
-                  ) where {N,L,S<:Shape{N,L}}
+function periodize(shp::S,  # shape to periodize
+                   A::SMatrix{N,N,<:Real},  # columns: primitive vectors of Bravais lattice
+                   ∆range::Shape{N}  # range of translation vectors; boundaries included
+                  ) where {N,S<:Shape{N}}
     # R = n₁a₁ + n₂a₂ + n₃a₃ is a translation vector for A = [a₁ a₂ a₃].  Find the ranges of
     # n₁, n₂, n₃ to test the inclusion of R in the Shape ∆range.
     #
@@ -45,7 +44,7 @@ function periodize(o::S,  # shape to periodize
     for n = CartesianRange(nrange)  # n: CartesianIndex
 		∆ = A * SVector(n.I)  # lattice vector R
 		if ∆ ∈ ∆range
-			shape = translate(o, ∆)
+			shape = translate(shp, ∆)
 			ishape += 1
 			shp_array[ishape] = shape
 		end

--- a/src/periodize.jl
+++ b/src/periodize.jl
@@ -1,3 +1,7 @@
+export periodize
+
+periodize(o::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(o, SMatrix{N,N}(A), ∆range)
+
 function periodize(o::S,  # shape to periodize
                    A::SMatrix{N,N,<:Real,L},  # columns are primitive vectors of lattice
                    ∆range::Shape{N,L}  # range of shift
@@ -19,7 +23,7 @@ function periodize(o::S,  # shape to periodize
     nmin = ceil.(Int, r * nmin_fl)  # SVector
 
     nshape = prod((nmax.-nmin).+1)  # tentative number of shapes
-    shape_array = Vector{S}(nshape)  # preallocation (will be trimmed later)
+    shp_array = Vector{S}(nshape)  # preallocation (will be trimmed later)
 
     ishape = 0
     nrange = map((n1,n2)->n1:n2, nmin.data, nmax.data)  # e.g., (1:10, 1:10, 1:10) for N = 3
@@ -28,9 +32,9 @@ function periodize(o::S,  # shape to periodize
 		if ∆ ∈ ∆range
 			shape = translate(o, ∆)
 			ishape += 1
-			shape_array[ishape] = shape
+			shp_array[ishape] = shape
 		end
     end
 
-    resize!(shape_array, ishape)  # return resized shape_array
+    resize!(shp_array, ishape)  # return resized shp_array
 end

--- a/src/periodize.jl
+++ b/src/periodize.jl
@@ -2,33 +2,48 @@ export periodize
 
 periodize(o::Shape{N}, A::AbstractMatrix, ∆range::Shape{N}) where {N} = periodize(o, SMatrix{N,N}(A), ∆range)
 
+
 function periodize(o::S,  # shape to periodize
-                   A::SMatrix{N,N,<:Real,L},  # columns are primitive vectors of lattice
-                   ∆range::Shape{N,L}  # range of shift
+                   A::SMatrix{N,N,<:Real,L},  # columns: primitive vectors of Bravais lattice
+                   ∆range::Shape{N,L}  # range of translation vectors; boundaries included
                   ) where {N,L,S<:Shape{N,L}}
-    ∆bound = bounds(∆range)  # bounds of shift range
-    nmax_fl = SVector(ntuple(k->-Inf,Val{N}))
-    nmin_fl = SVector(ntuple(k->Inf,Val{N}))
-    cr = CartesianRange(ntuple(k->2, Val{N}))  # (2,2,2) for N = 3
-    for ci = cr
-        cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVector(ci.I))  # SVector: corner of ∆bound (ci.I[k] = 1 or 2)
+    # R = n₁a₁ + n₂a₂ + n₃a₃ is a translation vector for A = [a₁ a₂ a₃].  Find the ranges of
+    # n₁, n₂, n₃ to test the inclusion of R in the Shape ∆range.
+    #
+    # The minimum and maximum nᵢ's to examine can be found by finding nᵢ's at the corners of
+    # the bounding box of ∆range.  This can be easily seen by unitary transformation of aᵢ's
+    # into the Cartesian directions.  The transformation transforms the lattice planes into
+    # the x-, y-, z-normal planes, and the bounding box into a parallelpiped.  The nᵢ's at
+    # the corners of the original bounding box corresponds to the Cartesian indices of the
+    # corners of the parallelpiped after transformation, and the minimum and maximum nᵢ's
+    # are the Cartesian indices of the corners of the bounding box of this post-transform
+    # parallelpiped.  Because the post-transform parallelpiped is enclosed by its bounding
+    # box, all the lattice points within the post-transform parallelpiped are also within
+    # the bounding box of the parallelpiped, whose corner indices are the minimum and
+    # maximum nᵢ's.
+    ∆bound = bounds(∆range)  # (SVector{3}, SVector{3}): bounds of translation range
+    nmax_fl = SVector(ntuple(k->-Inf, Val{N}))  # [-Inf, -Inf, -Inf] for N = 3
+    nmin_fl = SVector(ntuple(k->Inf, Val{N}))  # [Inf, Inf, Inf] for N = 3
+    rcart = CartesianRange(ntuple(k->2, Val{N}))  # (2,2,2) for N = 3
+    for icart = rcart  # icart: CartesianIndex (see, e.g., https://julialang.org/blog/2016/02/iteration)
+        cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVector(icart.I))  # SVector: corner of ∆bound (note icart.I[k] = 1 or 2)
         n_fl = A \ cnr  # SVector: A * n_fl = corner
         nmax_fl = max.(nmax_fl, n_fl)  # SVector
         nmin_fl = min.(nmin_fl, n_fl)  # SVector
     end
 
-    r = 1.0 - Base.rtoldefault(Float64)  # scale factor to multiply to exclude points on boundary
-    # Below, use `r.*` for fusion after StaticArrays Issue 390 is resolved.
-    nmax = floor.(Int, r * nmax_fl)  # SVector
-    nmin = ceil.(Int, r * nmin_fl)  # SVector
+    # Find the integral nᵢ's.
+    nmax = ceil.(Int, nmax_fl)  # SVector
+    nmin = floor.(Int, nmin_fl)  # SVector
 
+    # For nᵢ's within the range calculated above, check if R = n₁a₁ + n₂a₂ + n₃a₃ is within
+    # the Shape ∆range.  If it is, then create a shape transformed by R.
     nshape = prod((nmax.-nmin).+1)  # tentative number of shapes
-    shp_array = Vector{S}(nshape)  # preallocation (will be trimmed later)
-
+    shp_array = Vector{S}(nshape)  # preallocation (will be truncated later)
     ishape = 0
     nrange = map((n1,n2)->n1:n2, nmin.data, nmax.data)  # e.g., (1:10, 1:10, 1:10) for N = 3
-    for n = CartesianRange(nrange)
-		∆ = A * SVector(n.I)  # lattice vector
+    for n = CartesianRange(nrange)  # n: CartesianIndex
+		∆ = A * SVector(n.I)  # lattice vector R
 		if ∆ ∈ ∆range
 			shape = translate(o, ∆)
 			ishape += 1

--- a/src/periodize.jl
+++ b/src/periodize.jl
@@ -1,0 +1,36 @@
+function periodize(o::S,  # shape to periodize
+                   A::SMatrix{N,N,<:Real,L},  # columns are primitive vectors of lattice
+                   ∆range::Shape{N,L}  # range of shift
+                  ) where {N,L,S<:Shape{N,L}}
+    ∆bound = bounds(∆range)  # bounds of shift range
+    nmax_fl = SVector(ntuple(k->-Inf,Val{N}))
+    nmin_fl = SVector(ntuple(k->Inf,Val{N}))
+    cr = CartesianRange(ntuple(k->2, Val{N}))  # (2,2,2) for N = 3
+    for ci = cr
+        cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVector(ci.I))  # SVector: corner of ∆bound (ci.I[k] = 1 or 2)
+        n_fl = A \ cnr  # SVector: A * n_fl = corner
+        nmax_fl = max.(nmax_fl, n_fl)  # SVector
+        nmin_fl = min.(nmin_fl, n_fl)  # SVector
+    end
+
+    r = 1.0 - Base.rtoldefault(Float64)  # scale factor to multiply to exclude points on boundary
+    # Below, use `r.*` for fusion after StaticArrays Issue 390 is resolved.
+    nmax = floor.(Int, r * nmax_fl)  # SVector
+    nmin = ceil.(Int, r * nmin_fl)  # SVector
+
+    nshape = prod((nmax.-nmin).+1)  # tentative number of shapes
+    shape_array = Vector{S}(nshape)  # preallocation (will be trimmed later)
+
+    ishape = 0
+    nrange = map((n1,n2)->n1:n2, nmin.data, nmax.data)  # e.g., (1:10, 1:10, 1:10) for N = 3
+    for n = CartesianRange(nrange)
+		∆ = A * SVector(n.I)  # lattice vector
+		if ∆ ∈ ∆range
+			shape = translate(o, ∆)
+			ishape += 1
+			shape_array[ishape] = shape
+		end
+    end
+
+    resize!(shape_array, ishape)  # return resized shape_array
+end

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -21,4 +21,6 @@ function surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N}
     return s.c+s.r*nout, nout
 end
 
+translate(s::Sphere{N,L,D}, ∆::SVector{N}) where {N,L,D} = Sphere{N,L,D}(s.c+∆, s.r, s.data)
+
 bounds(s::Sphere) = (s.c-s.r, s.c+s.r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,7 @@ end
             @test checkbounds(s)
             @test checkbounds(Sphere([1,2,3], 2))
 
+            @test (∆ = rand(2); translate(s,∆) == Sphere([3,4]+∆, 5))
         end
 
         @testset "Box" begin
@@ -92,6 +93,8 @@ end
             @test bounds(Box([0,0], [2,4], [1 1; 1 -1])) ≈ ([-3*√0.5,-3*√0.5], [3*√0.5,3*√0.5])
             @test checkbounds(b)
             @test checkbounds(Box([0,0], [2,4], [1 1; 1 -1]))
+
+            @test (∆ = rand(2); translate(b,∆) == Box([0,0]+∆, [2,4]))
         end
 
         @testset "Box, rotated" begin
@@ -125,6 +128,8 @@ end
             ymax = (R*[-r1,r2])[2]
             @test bounds(br) ≈ (-[xmax,ymax], [xmax,ymax])
             @test checkbounds(br)
+
+            @test (∆ = rand(2); translate(br,∆) == Box([0,0]+∆, [2r1, 2r2], [ax1 ax2]))
         end
 
         @testset "Box, skewed" begin
@@ -151,6 +156,8 @@ end
             ymax = (r2*ax2-r1*ax1)[2]
             @test bounds(bs) ≈ (-[xmax,ymax],[xmax,ymax])
             @test checkbounds(bs)
+
+            @test (∆ = rand(2); translate(bs,∆) == Box([0,0]+∆, [2r1, 2r2], [ax1 ax2]))
         end
 
         @testset "Ellipsoid" begin
@@ -172,6 +179,8 @@ end
             @test bounds(e) == ([-1,-2],[1,2])
             @test checkbounds(e)
             @test checkbounds(Ellipsoid([0,0], [1,2], [1 1; 1 -1]))
+
+            @test (∆ = rand(2); translate(e,∆) == Ellipsoid([0,0]+∆, [1,2]))
 
             b = Box([0,0], [2,4])
             eb = Ellipsoid(b)
@@ -207,6 +216,8 @@ end
             @test bounds(er) == ([-xmax, -ymax], [xmax, ymax])
             @test checkbounds(er)
 
+            @test (∆ = rand(2); translate(er,∆) == Ellipsoid([0,0]+∆, [2,3], R))
+
             br = Box([0,0], 2*[2,3], R)
             ebr = Ellipsoid(br)
             @test er == ebr
@@ -239,6 +250,8 @@ end
             @test bounds(c) ≈ ([-0.3,-0.3,-1.1],[0.3,0.3,1.1])
             @test checkbounds(c)
             @test checkbounds(Cylinder([1,17,44], 0.3, [1,-2,3], 1.1))
+
+            @test (∆ = rand(3); translate(c,∆) == Cylinder([0,0,0]+∆, 0.3, [0,0,1], 2.2))
         end
 
         @testset "Cylinder, rotated" begin
@@ -267,6 +280,16 @@ end
 
             @test bounds(cr) ≈ (-[(1.1+0.3)/√2,0.3,(1.1+0.3)/√2], [(1.1+0.3)/√2,0.3,(1.1+0.3)/√2])
             @test checkbounds(cr)
+
+            @test (∆ = rand(3); translate(cr,∆) == Cylinder([0,0,0]+∆, 0.3, ax3, 2.2))
+        end
+
+        @testset "periodize" begin
+            c = Cylinder([0,0,0], 1, [0,0,1], 5)
+            bound = Box([0,0,0], [10,10,5])  # specify center and radii
+            A = [1 0 0; 0 1 0; 0 0 5]'
+            c_array = periodize(c, A, bound)
+            @test length(c_array) == (11-2)^2
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,11 +285,37 @@ end
         end
 
         @testset "periodize" begin
+            # Square lattice
             c = Cylinder([0,0,0], 1, [0,0,1], 5)
-            bound = Box([0,0,0], [10,10,5])  # specify center and radii
+            b = Box([0,0,0], [10,10,5])  # specify center and radii
             A = [1 0 0; 0 1 0; 0 0 5]'
-            c_array = periodize(c, A, bound)
+            c_array = periodize(c, A, b)
             @test length(c_array) == (11-2)^2
+
+            # Hexagonal lattice
+            using PyPlot
+            c = Cylinder([0,0,0], 1/4, [0,0,1], 1)
+            b = Box([0,0,0], [12,4*√3,1])  # specify center and radii
+            A = [1 0 0; 0.5 √3/2 0; 0 0 1]'
+            c_array = periodize(c, A, b)
+
+            bnd = bounds(b)
+            x = linspace(bnd[1][1], bnd[2][1], 120*5)
+            y = linspace(bnd[1][2], bnd[2][2], 70*5)
+            Nx, Ny = length(x), length(y)
+            X = repeat(x, outer=(1,Ny))
+            Y = repeat(y.', outer=(Nx,1))
+            V = zeros(Bool, Nx, Ny)
+
+            kd = KDTree(c_array)
+            for j = 1:Ny, i = 1:Nx
+                p = [x[i], y[j], 0.0]
+                s = findin(p, kd)
+                V[i,j] = !isnull(s)
+            end
+
+            axes(aspect="equal")
+            pcolor(X, Y, V, cmap="gray_r")
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,36 +286,55 @@ end
 
         @testset "periodize" begin
             # Square lattice
+            using GeometryPrimitives
             c = Cylinder([0,0,0], 1, [0,0,1], 5)
-            b = Box([0,0,0], [10,10,5])
+            ∆range = Box([0,0,0], [10,10,5])
             A = [1 0 0; 0 1 0; 0 0 5]'
-            c_array = periodize(c, A, b)
-            @test length(c_array) == (11-2)^2
-
-            # Hexagonal lattice
-            using PyPlot
-            c = Cylinder([0,0,0], 1/4, [0,0,1], 1)
-            b = Box([0,0,0], [12,4*√3,1])
-            A = [1 0 0; 0.5 √3/2 0; 0 0 1]'
-            c_array = periodize(c, A, b)
-
-            bnd = bounds(b)
-            x = linspace(bnd[1][1], bnd[2][1], 120*5)
-            y = linspace(bnd[1][2], bnd[2][2], 70*5)
-            Nx, Ny = length(x), length(y)
-            X = repeat(x, outer=(1,Ny))
-            Y = repeat(y.', outer=(Nx,1))
-            V = zeros(Bool, Nx, Ny)
+            c_array = periodize(c, A, ∆range)
+            # @test length(c_array) == 11^2  # test if correct number of cylinders are generated
 
             kd = KDTree(c_array)
-            for j = 1:Ny, i = 1:Nx
-                p = [x[i], y[j], 0.0]
+            result = true
+            for py = -5.0:5.0, px = -5.0:5.0
+                p = [px, py, 0.0]
                 s = findin(p, kd)
-                V[i,j] = !isnull(s)
+                result &= !isnull(s)  # test if any lattice point within ∆range is included in a cylinder
             end
+            @test result
 
-            axes(aspect="equal")
-            pcolor(X, Y, V, cmap="gray_r")
+            # Execute the following lines to test a hexagonal lattice visually.
+            # c = Cylinder([0,0,0], 1/4, [0,0,1], 1)
+            # ∆range = Box([0,0,0], [8,2*√3,1])
+            # A = [1 0 0; 0.5 √3/2 0; 0 0 1]'
+            # c_array = periodize(c, A, ∆range)
+            #
+            # b = Box([0,0,0], [12,4*√3,1])
+            # bnd = bounds(b)
+            # x = linspace(bnd[1][1], bnd[2][1], 120*5)
+            # y = linspace(bnd[1][2], bnd[2][2], 70*5)
+            # Nx, Ny = length(x), length(y)
+            # X = repeat(x, outer=(1,Ny))
+            # Y = repeat(y.', outer=(Nx,1))
+            # V = zeros(Bool, Nx, Ny)
+            #
+            # kd = KDTree(c_array)
+            # for j = 1:Ny, i = 1:Nx
+            #     p = [x[i], y[j], 0.0]
+            #     s = findin(p, kd)
+            #     V[i,j] = !isnull(s)
+            # end
+            #
+            # using PyPlot
+            # clf()
+            # axes(aspect="equal")
+            # pcolor(X, Y, V, cmap="gray_r")
+            #
+            # using PyCall
+            # @pyimport matplotlib.patches as patch
+            # b∆range = bounds(∆range)
+            # cnr = b∆range[1][1:2]
+            # w, h = -((-)(b∆range...)[1:2])
+            # gca()[:add_artist](patch.Rectangle(cnr, w, h, fill=false, edgecolor="r", linestyle="--"))
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,7 +287,7 @@ end
         @testset "periodize" begin
             # Square lattice
             c = Cylinder([0,0,0], 1, [0,0,1], 5)
-            b = Box([0,0,0], [10,10,5])  # specify center and radii
+            b = Box([0,0,0], [10,10,5])
             A = [1 0 0; 0 1 0; 0 0 5]'
             c_array = periodize(c, A, b)
             @test length(c_array) == (11-2)^2
@@ -295,7 +295,7 @@ end
             # Hexagonal lattice
             using PyPlot
             c = Cylinder([0,0,0], 1/4, [0,0,1], 1)
-            b = Box([0,0,0], [12,4*√3,1])  # specify center and radii
+            b = Box([0,0,0], [12,4*√3,1])
             A = [1 0 0; 0.5 √3/2 0; 0 0 1]'
             c_array = periodize(c, A, b)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,7 +286,6 @@ end
 
         @testset "periodize" begin
             # Square lattice
-            using GeometryPrimitives
             c = Cylinder([0,0,0], 1, [0,0,1], 5)
             ∆range = Box([0,0,0], [10,10,5])
             A = [1 0 0; 0 1 0; 0 0 5]'


### PR DESCRIPTION
This PR adds `periodize` that generates a periodic array of a given shape.  It takes three arguments:

- `shp`: `Shape` to periodize
- `A`: matrix whose columns are lattice primitive vectors
- `∆range`: `Shape` specifying the range of lattice points