### PR TITLE
Various updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 Compat
 StaticArrays

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,18 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
 
-matrix:
-  allow_failures:
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+#matrix:
+#  allow_failures:
+#  - julia_version: latest
 
 branches:
   only:
@@ -22,18 +26,13 @@ notifications:
     on_build_status_changed: false
 
 install:
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%";
       Pkg.clone(pwd(), \"GeometryPrimitives\"); Pkg.build(\"GeometryPrimitives\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"GeometryPrimitives\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -1,5 +1,5 @@
 module GeometryPrimitives
-using Compat, StaticArrays
+using Compat, StaticArrays, LinearAlgebra
 export Shape, surfpt_nearby, normal, bounds, translate
 
 abstract type Shape{N,L,D} end # a solid geometric shape in N dimensions (L = N*N is needed in some shapes, e.g., Box)

--- a/src/box.jl
+++ b/src/box.jl
@@ -9,7 +9,7 @@ mutable struct Box{N,L,D} <: Shape{N,L,D}
 end
 
 Box(c::SVector{N}, d::SVector{N},
-    axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N}(1.0I),  # columns are axes unit vectors
+    axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N,Float64}(I),  # columns are axes unit vectors
     data::D=nothing) where {N,L,D} =
     Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 

--- a/src/box.jl
+++ b/src/box.jl
@@ -13,7 +13,7 @@ Box(c::SVector{N}, d::SVector{N},
     data::D=nothing) where {N,L,D} =
     Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 
-Box(c::AbstractVector, d::AbstractVector, axes=Matrix(1.0I,length(c),length(c)), data=nothing) =
+Box(c::AbstractVector, d::AbstractVector, axes=Matrix{Float64}(I,length(c),length(c)), data=nothing) =
     (N = length(c); Box(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
 
 Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data

--- a/src/box.jl
+++ b/src/box.jl
@@ -9,11 +9,11 @@ mutable struct Box{N,L,D} <: Shape{N,L,D}
 end
 
 Box(c::SVector{N}, d::SVector{N},
-    axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
+    axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N}(1.0I),  # columns are axes unit vectors
     data::D=nothing) where {N,L,D} =
-    Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
+    Box{N,L,D}(c, 0.5d, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 
-Box(c::AbstractVector, d::AbstractVector, axes=eye(length(c)), data=nothing) =
+Box(c::AbstractVector, d::AbstractVector, axes=Matrix(1.0I,length(c),length(c)), data=nothing) =
     (N = length(c); Box(SVector{N}(c), SVector{N}(d), SMatrix{N,N}(axes), data))
 
 Base.:(==)(b1::Box, b2::Box) = b1.c==b2.c && b1.r==b2.r && b1.p==b2.p && b1.data==b2.data
@@ -29,13 +29,13 @@ end
 
 function surfpt_nearby(x::SVector{N}, b::Box{N}) where {N}
     ax = inv(b.p)  # axes
-    n = (b.p ./ sqrt.(sum(abs2,b.p,Val{2})[:,1]))  # rows are direction normals; do not take transpose
+    n = (b.p ./ sqrt.(sum(abs2,b.p,dims=Val(2))[:,1]))  # rows are direction normals; do not take transpose
 
     # Below, θ[i], the angle between ax[:,i] and n[i,:], is always acute, because the
     # diagonal entries of ax * b.p are positive (= 1).
-    cosθ = sum(ax.*n', Val{1})[1,:]
-    # cosθ = diag(n*ax)  # faster than SVector(ntuple(i -> ax[:,i]⋅n[i,:], Val{N}))
-    # assert(all(cosθ .≥ 0))
+    cosθ = sum(ax.*n', dims=Val(1))[1,:]
+    # cosθ = diag(n*ax)  # faster than SVector(ntuple(i -> ax[:,i]⋅n[i,:], Val(N)))
+    # @assert all(cosθ .≥ 0)
 
     d = b.p * (x - b.c)
     n = n .* copysign.(1.0,d)  # operation returns SMatrix (reason for leaving n untransposed)
@@ -64,6 +64,6 @@ signmatrix(b::Box{3}) = SMatrix{3,4}(1,1,1, -1,1,1, 1,-1,1, 1,1,-1)
 
 function bounds(b::Box)
     A = inv(b.p) .* b.r'
-    m = maximum(abs.(A * signmatrix(b)), Val{2})[:,1] # extrema of all 2^N corners of the box
+    m = maximum(abs.(A * signmatrix(b)), dims=Val(2))[:,1] # extrema of all 2^N corners of the box
     return (b.c-m,b.c+m)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -9,7 +9,7 @@ mutable struct Ellipsoid{N,L,D} <: Shape{N,L,D}
 end
 
 Ellipsoid(c::SVector{N}, r::SVector{N},
-          axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N}(1.0I),  # columns are axes unit vectors
+          axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N,Float64}(I),  # columns are axes unit vectors
           data::D=nothing) where {N,L,D} =
     Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -9,11 +9,11 @@ mutable struct Ellipsoid{N,L,D} <: Shape{N,L,D}
 end
 
 Ellipsoid(c::SVector{N}, r::SVector{N},
-          axes::SMatrix{N,N,<:Real,L}=@SMatrix(eye(N)),  # columns are axes unit vectors
+          axes::SMatrix{N,N,<:Real,L}=SMatrix{N,N}(1.0I),  # columns are axes unit vectors
           data::D=nothing) where {N,L,D} =
-    Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,Val{1}))), data)
+    Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 
-Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=eye(length(c)), data=nothing) =
+Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=Matrix(1.0I,length(c),length(c)), data=nothing) =
     (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(r), SMatrix{N,N}(axes), data))
 
 Ellipsoid(b::Box{N,L,D}, data::D=nothing) where {N,L,D} = Ellipsoid{N,L,D}(b.c, (b.r).^-2, b.p, data)
@@ -49,8 +49,8 @@ function surfpt_nearby(x::SVector{N}, b::Ellipsoid{N}) where {N}
     px₀ = (t*b.ri2 + 1) .* px  # surface point in ellipsoid coordinates
 
     # Transform back to the original coordinates.
-    x₀ = At_mul_B(b.p, px₀) + b.c
-    nout = normalize(At_mul_B(b.p, px .* b.ri2))
+    x₀ = transpose(b.p) * px₀ + b.c
+    nout = normalize(transpose(b.p) * (px .* b.ri2))
 
     return x₀, nout
 end
@@ -63,7 +63,7 @@ function boundpts(b::Ellipsoid{N}) where {N}
     # directions, respectively.
 
     r2 = 1 ./ b.ri2
-    ndir = b.p  # Cartesian directions in ellipsoid coordinates: b.p * eye(3)
+    ndir = b.p  # Cartesian directions in ellipsoid coordinates: b.p * I
 
     # In the ellipsoid coordinates, the point on the ellipsoid where the direction normal is
     # n is (n .* r2) / sqrt(r2' * n.^2).  Below is the broadcasted version of this over a
@@ -88,7 +88,7 @@ function bounds(b::Ellipsoid{N}) where {N}
     #
     # For the efficient implementation of NaN-ignoring maximum, see
     # https://discourse.julialang.org/t/inconsistency-between-findmax-and-maximum-with-respect-to-nan/4214/8
-    m = reducedim((x,y) -> x<y ? y : x, M, Val{2}, -Inf)[:,1]
+    m = reduce((x,y) -> x<y ? y : x, M, init=-Inf, dims=Val(2))[:,1]
 
     return (b.c-m,b.c+m)
 end

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -13,7 +13,7 @@ Ellipsoid(c::SVector{N}, r::SVector{N},
           data::D=nothing) where {N,L,D} =
     Ellipsoid{N,L,D}(c, float.(r).^-2, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))), data)
 
-Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=Matrix(1.0I,length(c),length(c)), data=nothing) =
+Ellipsoid(c::AbstractVector, r::AbstractVector, axes::AbstractMatrix=Matrix{Float64}(I,length(c),length(c)), data=nothing) =
     (N = length(c); Ellipsoid(SVector{N}(c), SVector{N}(r), SMatrix{N,N}(axes), data))
 
 Ellipsoid(b::Box{N,L,D}, data::D=nothing) where {N,L,D} = Ellipsoid{N,L,D}(b.c, (b.r).^-2, b.p, data)

--- a/src/periodize.jl
+++ b/src/periodize.jl
@@ -9,7 +9,7 @@ function periodize(shp::S,  # shape to periodize
     # R = n₁a₁ + n₂a₂ + n₃a₃ is a translation vector for A = [a₁ a₂ a₃].  Find the ranges of
     # n₁, n₂, n₃ to test the inclusion of R in the Shape ∆range.
     #
-    # The minimum and maximum nᵢ's to examine can be found by finding nᵢ's at the corners of
+    # The minimum and maximum nᵢ's to examine can be found by findfirstg nᵢ's at the corners of
     # the bounding box of ∆range.  This can be easily seen by unitary transformation of aᵢ's
     # into the Cartesian directions.  The transformation transforms the lattice planes into
     # the x-, y-, z-normal planes, and the bounding box into a parallelpiped.  The nᵢ's at
@@ -21,9 +21,9 @@ function periodize(shp::S,  # shape to periodize
     # the bounding box of the parallelpiped, whose corner indices are the minimum and
     # maximum nᵢ's.
     ∆bound = bounds(∆range)  # (SVector{3}, SVector{3}): bounds of translation range
-    nmax_fl = SVector(ntuple(k->-Inf, Val{N}))  # [-Inf, -Inf, -Inf] for N = 3
-    nmin_fl = SVector(ntuple(k->Inf, Val{N}))  # [Inf, Inf, Inf] for N = 3
-    rcart = CartesianRange(ntuple(k->2, Val{N}))  # (2,2,2) for N = 3
+    nmax_fl = SVector(ntuple(k->-Inf, Val(N)))  # [-Inf, -Inf, -Inf] for N = 3
+    nmin_fl = SVector(ntuple(k->Inf, Val(N)))  # [Inf, Inf, Inf] for N = 3
+    rcart = CartesianIndices(ntuple(k->2, Val(N)))  # (2,2,2) for N = 3
     for icart = rcart  # icart: CartesianIndex (see, e.g., https://julialang.org/blog/2016/02/iteration)
         cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVector(icart.I))  # SVector: corner of ∆bound (note icart.I[k] = 1 or 2)
         n_fl = A \ cnr  # SVector: A * n_fl = corner
@@ -38,10 +38,10 @@ function periodize(shp::S,  # shape to periodize
     # For nᵢ's within the range calculated above, check if R = n₁a₁ + n₂a₂ + n₃a₃ is within
     # the Shape ∆range.  If it is, then create a shape transformed by R.
     nshape = prod((nmax.-nmin).+1)  # tentative number of shapes
-    shp_array = Vector{S}(nshape)  # preallocation (will be truncated later)
+    shp_array = Vector{S}(undef, nshape)  # preallocation (will be truncated later)
     ishape = 0
     nrange = map((n1,n2)->n1:n2, nmin.data, nmax.data)  # e.g., (1:10, 1:10, 1:10) for N = 3
-    for n = CartesianRange(nrange)  # n: CartesianIndex
+    for n = CartesianIndices(nrange)  # n: CartesianIndex
 		∆ = A * SVector(n.I)  # lattice vector R
 		if ∆ ∈ ∆range
 			shape = translate(shp, ∆)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -16,7 +16,7 @@ Base.hash(s::Sphere, h::UInt) = hash(s.c, hash(s.r, hash(s.data, hash(:Sphere, h
 Base.in(x::SVector{N}, s::Sphere{N}) where {N} = sum(abs2, x - s.c) ≤ s.r^2
 
 function surfpt_nearby(x::SVector{N}, s::Sphere{N}) where {N}
-    nout = x==s.c ? SVector(ntuple(k -> k==1 ? 1.0 : 0.0, Val{N})) :  # nout = e₁ for x == s.c
+    nout = x==s.c ? SVector(ntuple(k -> k==1 ? 1.0 : 0.0, Val(N))) :  # nout = e₁ for x == s.c
                     normalize(x-s.c)
     return s.c+s.r*nout, nout
 end

--- a/src/vxlcut.jl
+++ b/src/vxlcut.jl
@@ -53,7 +53,7 @@ function edgedir_quadsect(cbits::UInt8)
     elseif cbits==0x33 || cbits==~0x33
         dir = Y
     else
-        assert(cbits==0x55 || cbits==~0x55)
+        @assert cbits==0x55 || cbits==~0x55
         dir = X
     end
 
@@ -62,18 +62,18 @@ end
 
 # Return the volume fraction when the plane croses a set of four parallel edges.
 function rvol_quadsect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, cbits::UInt8)
-    const w = edgedir_quadsect(cbits)
-    const ∆w = vxl[P][w] - vxl[N][w]
+    w = edgedir_quadsect(cbits)
+    ∆w = vxl[P][w] - vxl[N][w]
 
-    const u, v, _w = UVW[w]
-    const nu, nv, nw = nout[u], nout[v], nout[w]
-    const mean_cepts = 4nr₀
+    u, v, _w = UVW[w]
+    nu, nv, nw = nout[u], nout[v], nout[w]
+    mean_cepts = 4nr₀
     for sv = NP, su = NP
         mean_cepts -= nu*vxl[su][u] + nv*vxl[sv][v]
     end
     mean_cepts /=  nw * 4∆w
 
-    const sw = nw>0 ? N : P  # nw cannot be 0
+    sw = nw>0 ? N : P  # nw cannot be 0
     return abs(mean_cepts - vxl[sw][w]/∆w)
 end
 
@@ -83,17 +83,17 @@ end
 # Assume count_ones(cbits) ≤ 4.  Othewise, call this function with flipped nout, nr₀,
 # cbits.
 function rvol_gensect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, cbits::UInt8)
-    const s = (nout.<0) .+ 1
-    const c = corner(vxl, s[X], s[Y], s[Z])  # corner coordinates
-    const ∆ = vxl[P] - vxl[N]  # vxl edges
-    const nc = nout .* c
+    s = (nout.<0) .+ 1
+    c = corner(vxl, s[X], s[Y], s[Z])  # corner coordinates
+    ∆ = vxl[P] - vxl[N]  # vxl edges
+    nc = nout .* c
     rmax, rmid, rmin =  abs.(((nr₀-sum(nc)) .+ nc) ./ nout - c) ./ ∆ # (lengths from corner to intercetps) / (voxel edges)
 
-    # const nx, ny, nz = nout
-    # const sx, sy, sz = ((nx≥0 ? N : P), (ny≥0 ? N : P), (nz≥0 ? N : P))  # signs of corner
-    # const cx, cy, cz = vxl[nX][sx], vxl[nY][sy], vxl[nZ][sz]  # corner coordinates
-    # const ∆x, ∆y, ∆z = vxl[nX][nP]-vxl[nX][nN], vxl[nY][nP]-vxl[nY][nN], vxl[nZ][nP]-vxl[nZ][nN]  # voxel edges
-    # const nxcx, nycy, nzcz = nx*cx, ny*cy, nz*cz
+    # nx, ny, nz = nout
+    # sx, sy, sz = ((nx≥0 ? N : P), (ny≥0 ? N : P), (nz≥0 ? N : P))  # signs of corner
+    # cx, cy, cz = vxl[nX][sx], vxl[nY][sy], vxl[nZ][sz]  # corner coordinates
+    # ∆x, ∆y, ∆z = vxl[nX][nP]-vxl[nX][nN], vxl[nY][nP]-vxl[nY][nN], vxl[nZ][nP]-vxl[nZ][nN]  # voxel edges
+    # nxcx, nycy, nzcz = nx*cx, ny*cy, nz*cz
     # rmax, rmid, rmin =  # (lengths from corner to intercetps) / (voxel edges)
     #     abs((nr₀-nycy-nzcz)/nx-cx)/∆x, abs((nr₀-nzcz-nxcx)/ny-cy)/∆y, abs((nr₀-nxcx-nycy)/nz-cz)/∆z
 
@@ -103,7 +103,7 @@ function rvol_gensect(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, nr₀, cbits:
     if rmax < rmid; rmax, rmid = rmid, rmax; end
 
     # Calculate the volume of the triangular pyramid, and cut off appropriate corners.
-    const tmax = 1 - 1/rmax
+    tmax = 1 - 1/rmax
     rvol_core = 1 + tmax + tmax^2
 
     # Below, if rmax == Inf, rmid and rmin must be ≤ 1 in exact arithmetic and subtraction
@@ -137,11 +137,10 @@ half-space is described by the boundary plane.  The boundary plane is described 
 outward normal vector `nout = [nx, ny, nz]` and a point `r₀ = [rx, ry, rz]` on the plane.
 `nout` does not have to be normalized.
 """
-# Return the volume fraction rvol = vol(voxel ⋂ half-space) / vol(voxel).
 function volfrac(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, r₀::SVector{3})
-    const nr₀ = nout⋅r₀
-    const cbits, n_on = corner_bits(vxl, nout, nr₀)
-    const n_in = count_ones(cbits)  # number of corners contained
+    nr₀ = nout⋅r₀
+    cbits, n_on = corner_bits(vxl, nout, nr₀)
+    n_in = count_ones(cbits)  # number of corners contained
 
     if n_in == 8  # voxel is inside half-space
         rvol = 1.
@@ -152,7 +151,7 @@ function volfrac(vxl::NTuple{2,SVector{3}}, nout::SVector{3}, r₀::SVector{3})
     elseif n_in ≤ 4 # general cases with n_in ≤ 4
         rvol = rvol_gensect(vxl, nout, nr₀, cbits)
     else  # general cases with n_in ≥ 5
-        assert(n_in ≥ 5)
+        @assert n_in ≥ 5
         rvol = 1. - rvol_gensect(vxl, .-nout, -nr₀, ~cbits)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,7 +314,7 @@ end
             # y = linspace(bnd[1][2], bnd[2][2], 70*5)
             # Nx, Ny = length(x), length(y)
             # X = repeat(x, outer=(1,Ny))
-            # Y = repeat(y.', outer=(Nx,1))
+            # Y = repeat(transpose(y), outer=(Nx,1))
             # V = zeros(Bool, Nx, Ny)
             #
             # kd = KDTree(c_array)


### PR DESCRIPTION
This PR closes #31 by making various changes to make the package work for Julia 0.7.

The biggest change is to follow the new conventions for the `find*` functions.  There was `findin` in `kdtree.jl` to find a shape in `KDTree` containing a given point, but `Base.findin` is deprecated in 0.7 and the use of `findall(in(kdtree), point)` is  recommended instead.  If we implement `in(::KDTree)` for this usage, we also need to implement `enumerate(::KDTree)` because `findall` needs a mechanism to get a linear index of the found shape in `KDTree`.  Because `KDTree` is meant to store shapes in a tree structure rather than a linear list, implementing `enumerate(::KDTree)` is awkward.

Moreover, the original `findin` for `KDTree` did not return all the shapes containing a given point, but only one such shape found first.  Therefore, using `findall(in(kdtree), point)` doesn't seem appropriate for the functionality we aim to implement here.

Therefore, I've decided to overload `Base.findfirst` instead of `Base.findin` for `KDTree`.  The name of `findfirst` correctly represents the functionality we aim to implement, and we can easily overload `Base.findfirst` without having to implement `in(::KDTree)` and `enumerate(::KDTree)`.