### PR TITLE
Fix scope of `AbbreviatedTypes` variables

### DIFF
--- a/test/cylinder.jl
+++ b/test/cylinder.jl
@@ -3,7 +3,7 @@
     @test c == deepcopy(c)
     @test hash(c) == hash(deepcopy(c))
     @test [0.2,0.2,1] ∈ c
-    @test SVec(0.2,0.2,1.2) ∉ c
+    @test GeometryPrimitives.SVec(0.2,0.2,1.2) ∉ c
     @test [0.2,0.25,1] ∉ c
 
     @test ((x,nout) = surfpt_nearby([0,0,0],c); (x≈[0,0,1.1] && nout≈[0,0,1]) || (x≈[0.3,0,0] && nout≈[1,0,0]) || (x≈[0,0.3,0] && nout≈[0,1,0]))  # handle point at center properly
@@ -11,9 +11,9 @@
     @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # outside corners
     @test all([(p = [0.3sx,0,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sx = (-1,1), sz = (-1,1)])  # outside corners
     @test all([(p = [0,0.3sy,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sy = (-1,1), sz = (-1,1)])  # outside corners
-    @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 sy 0; 0 0 sz]*nout.≥-10τₐ₀))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # on rims
-    @test all([(p = [0.3sx,0,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 0 sz]*nout.≥-10τₐ₀))) for sx = (-1,1), sz = (-1,1)])  # on rims
-    @test all([(p = [0,0.3sy,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([0 sy 0; 0 0 sz]*nout.≥-10τₐ₀))) for sy = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 sy 0; 0 0 sz]*nout.≥-10GeometryPrimitives.τₐ₀))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0.3sx,0,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 0 sz]*nout.≥-10GeometryPrimitives.τₐ₀))) for sx = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0,0.3sy,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([0 sy 0; 0 0 sz]*nout.≥-10GeometryPrimitives.τₐ₀))) for sy = (-1,1), sz = (-1,1)])  # on rims
     @test all([(p = [0.3sx/√2/2,0.3sy/√2/2,1.1sz]; surfpt_nearby([p[1],p[2],ρ*p[3]],c) ≈ (p,[0,0,sz])) for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,0,1), sy = (-1,0,1), sz = (-1,1)])  # around bases
     @test all([(p = [0.3sx,0,1.1sz/2]; surfpt_nearby([ρ*p[1],p[2],p[3]],c) ≈ (p,[sx,0,0])) for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,1), sz = (-1,0,1)])  # around side
     @test all([(p = [0,0.3sy,1.1sz/2]; surfpt_nearby([p[1],ρ*p[2],p[3]],c) ≈ (p,[0,sy,0])) for ρ = (one⁻⁻,1,one⁺⁺), sy = (-1,1), sz = (-1,0,1)])  # around side
@@ -42,9 +42,9 @@ end  # @testset "Cylinder"
     @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # outside corners
     @test all([(p = 0.3s1*ax1+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s1 = (-1,1), s3 = (-1,1)])  # outside corners
     @test all([(p = 0.3s2*ax2+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s2 = (-1,1), s3 = (-1,1)])  # outside corners
-    @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s2*ax2 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # on rims
-    @test all([(p = 0.3s1*ax1+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s3 = (-1,1)])  # on rims
-    @test all([(p = 0.3s2*ax2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s2*ax2 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s2 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s2*ax2 s3*ax3]'*nout.≥-10GeometryPrimitives.τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3s1*ax1+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s3*ax3]'*nout.≥-10GeometryPrimitives.τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3s2*ax2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s2*ax2 s3*ax3]'*nout.≥-10GeometryPrimitives.τₐ₀) && norm(nout)≈1)) for s2 = (-1,1), s3 = (-1,1)])  # on rims
     @test all([surfpt_nearby(0.3(s1*ax1+s2*ax2)/√2/2+ρ*1.1s3*ax3,cr) ≈ (0.3(s1*ax1+s2*ax2)/√2/2+1.1s3*ax3,s3*ax3) for ρ = (one⁻⁻,1,one⁺⁺), s1 = (-1,0,1), s2 = (-1,0,1), s3 = (-1,1)])  # around bases
     @test all([surfpt_nearby(ρ*0.3s1*ax1+1.1s3*ax3/2,cr) ≈ (0.3s1*ax1+1.1s3*ax3/2, s1*ax1) for ρ = (one⁻⁻,1,one⁺⁺), s1 = (-1,1), s3 = (-1,0,1)])  # around side
     @test all([surfpt_nearby(ρ*0.3s2*ax2+1.1s3*ax3/2,cr) ≈ (0.3s2*ax2+1.1s3*ax3/2, s2*ax2) for ρ = (one⁻⁻,1,one⁺⁺), s2 = (-1,1), s3 = (-1,0,1)])  # around side

--- a/test/kdtree.jl
+++ b/test/kdtree.jl
@@ -11,8 +11,8 @@
     @test findfirst([10.1,1], kd) == nothing
     @test checktree(kd, s)
 
-    s = Shape3[Ball(SVec(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
+    s = Shape3[Ball(GeometryPrimitives.SVec(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
     @test checktree(KDTree(s), s)
-    s = Shape3[Ball(SVec(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
+    s = Shape3[Ball(GeometryPrimitives.SVec(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
     @test checktree(KDTree(s), s)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,8 @@ using Random: MersenneTwister
 using Statistics: mean
 using Test
 
-const one⁻ = 1 - τᵣ₀  # scale factor slightly less than 1
-const one⁺ = 1 + τᵣ₀  # scare factor slightly greater than 1
+const one⁻ = 1 - GeometryPrimitives.τᵣ₀  # scale factor slightly less than 1
+const one⁺ = 1 + GeometryPrimitives.τᵣ₀  # scare factor slightly greater than 1
 const one⁻⁻, one⁺⁺ = 0.9, 1.1  # (scale factor less than 1, scale factor greater than 1)
 
 Base.isapprox(a::Tuple, b::Tuple; kws...) = all(p -> isapprox(p...; kws...), zip(a,b))
@@ -33,8 +33,8 @@ function checkbounds(s::Shape{N}, ntrials=10^4) where {N}
 end
 
 function checktree(t::KDTree{N}, slist::Vector{<:Shape{N}}, ntrials=10^3) where {N}
-    lb = SVec{N}(fill(Inf,N))
-    ub = SVec{N}(fill(-Inf,N))
+    lb = GeometryPrimitives.SVec{N}(fill(Inf,N))
+    ub = GeometryPrimitives.SVec{N}(fill(-Inf,N))
     for i in eachindex(slist)
         lbi,ubi = bounds(slist[i])
         lb = min.(lb,lbi)

--- a/test/vxlcut.jl
+++ b/test/vxlcut.jl
@@ -1,52 +1,52 @@
 @testset "triangular cylinder 3D" begin
-    vxl = (SVec(0,0,0), SVec(1,1,1))
-    nout = SVec(1,1,0)
+    vxl = (GeometryPrimitives.SVec(0,0,0), GeometryPrimitives.SVec(1,1,1))
+    nout = GeometryPrimitives.SVec(1,1,0)
 
-    @test_nowarn (r₀ = SVec(0.5,0,0); @inferred(volfrac(vxl, nout, r₀)))
-    @test (r₀ = SVec(0.5,0,0); volfrac(vxl, nout, r₀) ≈ 0.125)
-    @test (r₀ = SVec(0.5,0,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
-    @test (r₀ = SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0,0); nout = SVec(1,2,0); volfrac(vxl, nout, r₀) ≈ 0.25)
-    @test (r₀ = SVec(1,0,0); nout = SVec(1,2,0); volfrac(vxl, -nout, r₀) ≈ 0.75)
+    @test_nowarn (r₀ = GeometryPrimitives.SVec(0.5,0,0); @inferred(volfrac(vxl, nout, r₀)))
+    @test (r₀ = GeometryPrimitives.SVec(0.5,0,0); volfrac(vxl, nout, r₀) ≈ 0.125)
+    @test (r₀ = GeometryPrimitives.SVec(0.5,0,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
+    @test (r₀ = GeometryPrimitives.SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0.5)
+    @test (r₀ = GeometryPrimitives.SVec(1,0,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
+    @test (r₀ = GeometryPrimitives.SVec(1,0,0); nout = GeometryPrimitives.SVec(1,2,0); volfrac(vxl, nout, r₀) ≈ 0.25)
+    @test (r₀ = GeometryPrimitives.SVec(1,0,0); nout = GeometryPrimitives.SVec(1,2,0); volfrac(vxl, -nout, r₀) ≈ 0.75)
 end  # @testset "triangular cylinder 3D"
 
 @testset "triangular cylinder 2D" begin
-    vxl = (SVec(0,0), SVec(1,1))
-    nout = SVec(1,1)
+    vxl = (GeometryPrimitives.SVec(0,0), GeometryPrimitives.SVec(1,1))
+    nout = GeometryPrimitives.SVec(1,1)
 
-    @test_nowarn (r₀ = SVec(0.5,0); @inferred(volfrac(vxl, nout, r₀)))
-    @test (r₀ = SVec(0.5,0); volfrac(vxl, nout, r₀) ≈ 0.125)
-    @test (r₀ = SVec(0.5,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
-    @test (r₀ = SVec(1,0); volfrac(vxl, nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0); nout = SVec(1,2); volfrac(vxl, nout, r₀) ≈ 0.25)
-    @test (r₀ = SVec(1,0); nout = SVec(1,2); volfrac(vxl, -nout, r₀) ≈ 0.75)
+    @test_nowarn (r₀ = GeometryPrimitives.SVec(0.5,0); @inferred(volfrac(vxl, nout, r₀)))
+    @test (r₀ = GeometryPrimitives.SVec(0.5,0); volfrac(vxl, nout, r₀) ≈ 0.125)
+    @test (r₀ = GeometryPrimitives.SVec(0.5,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
+    @test (r₀ = GeometryPrimitives.SVec(1,0); volfrac(vxl, nout, r₀) ≈ 0.5)
+    @test (r₀ = GeometryPrimitives.SVec(1,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
+    @test (r₀ = GeometryPrimitives.SVec(1,0); nout = GeometryPrimitives.SVec(1,2); volfrac(vxl, nout, r₀) ≈ 0.25)
+    @test (r₀ = GeometryPrimitives.SVec(1,0); nout = GeometryPrimitives.SVec(1,2); volfrac(vxl, -nout, r₀) ≈ 0.75)
 end  # @testset "triangular cylinder 2D"
 
 @testset "quadrangular cylinder 3D" begin
-    @test_nowarn @inferred(volfrac((SVec(0,0,0),SVec(1,1,1)), SVec(1,2,0), SVec(0.5,0.5,0.5)))
+    @test_nowarn @inferred(volfrac((GeometryPrimitives.SVec(0,0,0),GeometryPrimitives.SVec(1,1,1)), GeometryPrimitives.SVec(1,2,0), GeometryPrimitives.SVec(0.5,0.5,0.5)))
     @test begin
         result = true
         for i = 1:100
-            vxl = (-@SVector(rand(3)), @SVector(rand(3)))
+            vxl = (-@GeometryPrimitives.SVector(rand(3)), @GeometryPrimitives.SVector(rand(3)))
             r₀ = mean(vxl)
             nout = randn(3)
             nout[rand(1:3)] = 0
-            result &= volfrac(vxl, SVec{3}(nout), r₀)≈0.5
+            result &= volfrac(vxl, GeometryPrimitives.SVec{3}(nout), r₀)≈0.5
         end
         result
     end
 end  # @testset "quadrangular cylinder 3D"
 
 @testset "quadrangular cylinder 2D" begin
-    @test_nowarn @inferred(volfrac((SVec(0,0),SVec(1,1)), SVec(1,2), SVec(0.5,0.5)))
+    @test_nowarn @inferred(volfrac((GeometryPrimitives.SVec(0,0),GeometryPrimitives.SVec(1,1)), GeometryPrimitives.SVec(1,2), GeometryPrimitives.SVec(0.5,0.5)))
     @test begin
         result = true
         for i = 1:100
-            vxl = (-@SVector(rand(2)), @SVector(rand(2)))
+            vxl = (-@GeometryPrimitives.SVector(rand(2)), @GeometryPrimitives.SVector(rand(2)))
             r₀ = mean(vxl)
-            nout = @SVector randn(2)
+            nout = @GeometryPrimitives.SVector randn(2)
             result &= volfrac(vxl, nout, r₀)≈0.5
         end
         result
@@ -55,13 +55,13 @@ end  # @testset "quadrangular cylinder 2D"
 
 @testset "general cases" begin
     # Test random cases.
-    @test_nowarn @inferred(volfrac((-@SVector(rand(3)),@SVector(rand(3))), SVec(0,0,0), @SVector(randn(3))))
+    @test_nowarn @inferred(volfrac((-@GeometryPrimitives.SVector(rand(3)),@GeometryPrimitives.SVector(rand(3))), GeometryPrimitives.SVec(0,0,0), @GeometryPrimitives.SVector(randn(3))))
     @test begin
         result = true
         for i = 1:100
-            vxl = (-@SVector(rand(3)), @SVector(rand(3)))
+            vxl = (-@GeometryPrimitives.SVector(rand(3)), @GeometryPrimitives.SVector(rand(3)))
             r₀ = mean(vxl)
-            nout = @SVector randn(3)
+            nout = @GeometryPrimitives.SVector randn(3)
             result &= volfrac(vxl, nout, r₀)≈0.5
         end
         result
@@ -70,42 +70,42 @@ end  # @testset "quadrangular cylinder 2D"
     @test begin
         result = true
         for i = 1:100
-            vxl = (-@SVector(rand(3)), @SVector(rand(3)))
-            r₀ = @SVector randn(3)
-            nout = @SVector randn(3)
+            vxl = (-@GeometryPrimitives.SVector(rand(3)), @GeometryPrimitives.SVector(rand(3)))
+            r₀ = @GeometryPrimitives.SVector randn(3)
+            nout = @GeometryPrimitives.SVector randn(3)
             result &= (volfrac(vxl, nout, r₀) + volfrac(vxl, -nout, r₀) ≈ 1)
         end
         result
     end
 
     # Test boundary cases.
-    vxl = (SVec(0,0,0), SVec(1,1,1))
-    r₀ = SVec(0,0,0)
-    @test (nout = SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,0,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(1,1,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,-1,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(1,1,1); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,-1,-1); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(-1,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_tricyl()
-    @test (nout = SVec(-1,-1,1); volfrac(vxl, nout, r₀) ≈ 5/6)  # rvol_gensect()
-    @test (nout = SVec(1,-2,1); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadsect()
-    r₀ = SVec(0.5,0.5,0)
-    @test (nout = SVec(-2,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadcyl()
+    vxl = (GeometryPrimitives.SVec(0,0,0), GeometryPrimitives.SVec(1,1,1))
+    r₀ = GeometryPrimitives.SVec(0,0,0)
+    @test (nout = GeometryPrimitives.SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = GeometryPrimitives.SVec(-1,0,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = GeometryPrimitives.SVec(1,1,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = GeometryPrimitives.SVec(-1,-1,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = GeometryPrimitives.SVec(1,1,1); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = GeometryPrimitives.SVec(-1,-1,-1); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = GeometryPrimitives.SVec(-1,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_tricyl()
+    @test (nout = GeometryPrimitives.SVec(-1,-1,1); volfrac(vxl, nout, r₀) ≈ 5/6)  # rvol_gensect()
+    @test (nout = GeometryPrimitives.SVec(1,-2,1); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadsect()
+    r₀ = GeometryPrimitives.SVec(0.5,0.5,0)
+    @test (nout = GeometryPrimitives.SVec(-2,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadcyl()
 
     # Test tolerance to floating-point arithmetic.
-    vxl = (SVec(0,9.5,0), SVec(1,10.5,1))
-    r₀ = SVec(0.5,10.0,0.5)
-    nout = SVec(0.0,1/√2,1/√2)
+    vxl = (GeometryPrimitives.SVec(0,9.5,0), GeometryPrimitives.SVec(1,10.5,1))
+    r₀ = GeometryPrimitives.SVec(0.5,10.0,0.5)
+    nout = GeometryPrimitives.SVec(0.0,1/√2,1/√2)
     @test volfrac(vxl, nout, r₀) ≈ 0.5
 
     # Test rvol_quadsect() for nontrivial cases.
-    vxl = (SVec(0,0,0), SVec(1,1,2))
-    r₀ = SVec(0.5, 0.5, 0.5)
+    vxl = (GeometryPrimitives.SVec(0,0,0), GeometryPrimitives.SVec(1,1,2))
+    r₀ = GeometryPrimitives.SVec(0.5, 0.5, 0.5)
     @test begin
         result = true
         for i = 1:100
-            nout = SVec(randn()/20, randn()/20, 1)
+            nout = GeometryPrimitives.SVec(randn()/20, randn()/20, 1)
             result &= volfrac(vxl, nout, r₀)≈0.5/2
         end
         result


### PR DESCRIPTION
Fixes tests, which broke after 9875b20.

I simply added the proper namespace (`GeometryPrimitives`) to the `AbbreviatedTypes` variables.