### PR TITLE
remove AbbreviatedTypes usage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,18 +3,18 @@ uuid = "17051e67-205e-509e-8301-03b320b998e6"
 license = "MIT"
 desc = "geometric primitives for piecewise functions on grids"
 authors = ["Steven G. Johnson, Wonseok Shin <wsshin97@gmail.com>, and contributors"]
-version = "0.4.6"
+version = "0.5"
 
 [deps]
-AbbreviatedTypes = "1766def0-c946-4dda-a59e-d0d07f8410f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AbbreviatedTypes = "0.2 - 0.9"
-Makie = "0.16 - 0.99"
-julia = "1.7 - 1"
+Makie = "0.16,0.17,0.18,0.19"
+julia = "1.7"
+StaticArrays = "1.5"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/GeometryPrimitives.jl
+++ b/src/GeometryPrimitives.jl
@@ -1,5 +1,6 @@
 module GeometryPrimitives
-using AbbreviatedTypes; @define_types_with(Float64)
+
+using StaticArrays
 using LinearAlgebra
 using Statistics: mean
 using Makie
@@ -14,27 +15,31 @@ const Shape3 = Shape{3,9}
 
 Base.ndims(::Shape{N}) where {N} = N
 
+# relative tolerance * x (assumed ≥ 0) for approximate comparisons,
+# defined to square root of machine precision like Base.rtoldefault
+rtol(x::AbstractFloat) = sqrt(eps(typeof(x))) * x
+
 # The following functions return Any due to the limitations of Julia's dispatch system.
 # Therefore, always call them with return type assertions.  See
 # https://discourse.julialang.org/t/extending-base-in-type-stably/5341/12
 # https://github.com/JuliaLang/julia/issues/23210
-level(x::AbsVecReal, s::Shape{N}) where {N} = level(SVec{N}(x), s)
-Base.in(x::AbsVecReal, s::Shape{N}) where {N} = level(x,s) ≥ 0
-surfpt_nearby(x::AbsVecReal, s::Shape{N}) where {N} = surfpt_nearby(SVec{N}(x), s)
-normal(x::AbsVecReal, s::Shape) = surfpt_nearby(x, s)[2]  # outward direction even for x inside s
-translate(s::Shape{N}, ∆::AbsVecReal) where {N} = translate(s, SVec{N}(∆))
-translate(s::Shape{N}, ∆::SReal{N}) where {N} = (s2 = deepcopy(s); s2.c += ∆; s2)  # default implementation
+level(x::AbstractVector{<:Real}, s::Shape{N}) where {N} = level(SVector{N}(x), s)
+Base.in(x::AbstractVector{<:Real}, s::Shape{N}) where {N} = level(x,s) ≥ 0
+surfpt_nearby(x::AbstractVector{<:Real}, s::Shape{N}) where {N} = surfpt_nearby(SVector{N}(x), s)
+normal(x::AbstractVector{<:Real}, s::Shape) = surfpt_nearby(x, s)[2]  # outward direction even for x inside s
+translate(s::Shape{N}, ∆::AbstractVector{<:Real}) where {N} = translate(s, SVector{N}(∆))
+translate(s::Shape{N}, ∆::SVector{N,<:Real}) where {N} = (s2 = deepcopy(s); s2.c += ∆; s2)  # default implementation
 
-function orthoaxes(n::SReal{3})
-    u_temp = abs(n[3]) < abs(n[1]) ? SVec(0,0,1) : SVec(1,0,0)
+function orthoaxes(n::SVector{3,<:Real})
+    u_temp = abs(n[3]) < abs(n[1]) ? SVector(0,0,1) : SVector(1,0,0)
     v = normalize(n × u_temp)
     u = v × n
 
     return u, v
 end
 
-function orthoaxes(n::SReal{N}) where {N}
-    u_temp = abs(n[3]) < abs(n[1]) ? SVec(0,0,1) : SVec(1,0,0)
+function orthoaxes(n::SVector{N,<:Real}) where {N}
+    u_temp = abs(n[3]) < abs(n[1]) ? SVector(0,0,1) : SVector(1,0,0)
     v = normalize(n × u_temp)
     u = v × n
 

--- a/src/hyper/ball.jl
+++ b/src/hyper/ball.jl
@@ -1,22 +1,22 @@
 export Ball
 
 mutable struct Ball{N,N²} <: Shape{N,N²}
-    c::SFloat{N}  # center of ball
-    r::Float  # radius
+    c::SVector{N,Float64}  # center of ball
+    r::Float64  # radius
     Ball{N,N²}(c,r) where {N,N²} = new(c,r)  # suppress default outer constructor
 end
 
-Ball(c::SReal{N}, r::Real) where {N} = Ball{N,N*N}(c, r)
-Ball(c::AbsVecReal, r::Real) = (N = length(c); Ball(SVec{N}(c), r))
+Ball(c::SVector{N,<:Real}, r::Real) where {N} = Ball{N,N*N}(c, r)
+Ball(c::AbstractVector{<:Real}, r::Real) = (N = length(c); Ball(SVector{N}(c), r))
 
 Base.:(==)(s1::Ball, s2::Ball) = s1.c==s2.c && s1.r==s2.r
 Base.isapprox(s1::Ball, s2::Ball) = s1.c≈s2.c && s1.r≈s2.r
 Base.hash(s::Ball, h::UInt) = hash(s.c, hash(s.r, hash(:Ball, h)))
 
-level(x::SReal{N}, s::Ball{N}) where {N} = 1.0 - √(sum(abs2, x - s.c) / s.r^2)
+level(x::SVector{N,<:Real}, s::Ball{N}) where {N} = 1.0 - √(sum(abs2, x - s.c) / s.r^2)
 
-function surfpt_nearby(x::SReal{N}, s::Ball{N}) where {N}
-    nout = x==s.c ? SVec(ntuple(k -> k==1 ? 1.0 : 0.0, Val(N))) :  # nout = e₁ for x == s.c
+function surfpt_nearby(x::SVector{N,<:Real}, s::Ball{N}) where {N}
+    nout = x==s.c ? SVector(ntuple(k -> k==1 ? 1.0 : 0.0, Val(N))) :  # nout = e₁ for x == s.c
                     normalize(x-s.c)
     return s.c+s.r*nout, nout
 end

--- a/src/planar/cross_section.jl
+++ b/src/planar/cross_section.jl
@@ -2,23 +2,23 @@ export CrossSection
 
 mutable struct CrossSection{S<:Shape3} <: Shape2
     shp::S  # 3D shape
-    p::S²Float{3,9}  # projection matrix to cross-sectional coordinates; must be orthonormal; 3rd entry of projection is along normal axis
-    c::Float  # intercept on axis normal to cross section
+    p::SMatrix{3,3,Float64,9}  # projection matrix to cross-sectional coordinates; must be orthonormal; 3rd entry of projection is along normal axis
+    c::Float64  # intercept on axis normal to cross section
 end
 
 CrossSection(shp::S,
-             n::SReal{3},
+             n::SVector{3,<:Real},
              c::Real
              ) where {S<:Shape3} =
     (n̂ = normalize(n); CrossSection{S}(shp, [orthoaxes(n̂)... n̂]', c))
 
-CrossSection(shp::Shape3, n::AbsVecReal, c::Real) = CrossSection(shp, SVec{3}(n), c)
+CrossSection(shp::Shape3, n::AbstractVector{<:Real}, c::Real) = CrossSection(shp, SVector{3}(n), c)
 
 function (shp::Shape3)(ax::Symbol, c::Real)
     ax==:x || ax==:y || ax==:z || @error "ax = $(ax) should be :x or :y or :z."
 
     ind_n̂ = (ax==:x) + 2(ax==:y) + 3(ax==:z)  # ind_n̂ = 1, 2, 3 for ax = :x, :y, :z
-    n̂ = SVec(ntuple(identity,Val(3))) .== ind_n̂
+    n̂ = SVector(ntuple(identity,Val(3))) .== ind_n̂
 
     return CrossSection(shp, n̂, c)
 end
@@ -27,15 +27,15 @@ Base.:(==)(s1::CrossSection, s2::CrossSection) = s1.shp==s2.shp && s1.p==s2.p  &
 Base.isapprox(s1::CrossSection, s2::CrossSection) = s1.shp≈s2.shp && s1.p≈s2.p  && s1.c≈s2.c
 Base.hash(s::CrossSection, h::UInt) = hash(s.shp, hash(s.p, hash(s.c, hash(:CrossSection, h))))
 
-coord3d(x::SReal{2}, s::CrossSection) = (y = SFloat{3}(x..., s.c); s.p' * y)
+coord3d(x::SVector{2,<:Real}, s::CrossSection) = (y = SVector{3,Float64}(x..., s.c); s.p' * y)
 
-level(x::SReal{2}, s::CrossSection) = level(coord3d(x,s), s.shp)
+level(x::SVector{2,<:Real}, s::CrossSection) = level(coord3d(x,s), s.shp)
 
-function surfpt_nearby(x::SReal{2}, s::CrossSection)
+function surfpt_nearby(x::SVector{2,<:Real}, s::CrossSection)
     @error "surfpt_nearby(x,s) is not supported for s::CrossSection."
 end
 
-translate(s::CrossSection, ∆::SReal{2}) = CrossSection(translate(s.shp, coord3d(∆,s)), s.p, s.c)
+translate(s::CrossSection, ∆::SVector{2,<:Real}) = CrossSection(translate(s.shp, coord3d(∆,s)), s.p, s.c)
 
 # This does not create the tightest bounds.  For the tightest bounds, this function should
 # be implemented for CrossSection{S} for each S<:Shape3.

--- a/src/planar/polygon.jl
+++ b/src/planar/polygon.jl
@@ -6,64 +6,64 @@ export Polygon
 # - The polygon is convex.
 # - The vertices are listed in the counter-clockwise order around the origin.
 mutable struct Polygon{K,K2} <: Shape2  # K2 = 2K
-    v::SMat{2,K,Float,K2}  # vertices
-    n::SMat{2,K,Float,K2}  # direction normals to edges
+    v::SMatrix{2,K,Float64,K2}  # vertices
+    n::SMatrix{2,K,Float64,K2}  # direction normals to edges
     Polygon{K,K2}(v,n) where {K,K2} = new(v,n)  # suppress default outer constructor
 end
 
-function Polygon(v::SMat{2,K,<:Real}) where {K}
+function Polygon(v::SMatrix{2,K,<:Real}) where {K}
     # Sort the vertices in the counter-clockwise direction
     w = v .- mean(v, dims=Val(2))  # v in center-of-mass coordinates
-    ϕ = mod.(atan.(w[2,:], w[1,:]), 2π)  # SVec{K}: angle of vertices between 0 and 2π; `%` does not work for negative angle
+    ϕ = mod.(atan.(w[2,:], w[1,:]), 2π)  # SVector{K}: angle of vertices between 0 and 2π; `%` does not work for negative angle
     if !issorted(ϕ)
         # Do this only when ϕ is not sorted, because the following uses allocations.
-        ind = MVec{K}(sortperm(ϕ))  # sortperm(::SVec) currently returns Vector, not MVector
-        v = v[:,ind]  # SVec{K}: sorted v
+        ind = MVector{K}(sortperm(ϕ))  # sortperm(::SVector) currently returns Vector, not MVector
+        v = v[:,ind]  # SVector{K}: sorted v
     end
 
     # Calculate the increases in angle between neighboring edges.
-    ∆v = hcat(diff(v, dims=Val(2)), SMat{2,1}(v[:,1]-v[:,end]))  # SMat{2,K}: edge directions
-    ∆z = ∆v[1,:] + im * ∆v[2,:]  # SVec{K}: edge directions as complex numbers
+    ∆v = hcat(diff(v, dims=Val(2)), SMatrix{2,1}(v[:,1]-v[:,end]))  # SMatrix{2,K}: edge directions
+    ∆z = ∆v[1,:] + im * ∆v[2,:]  # SVector{K}: edge directions as complex numbers
     icurr = ntuple(identity, Val(K-1))
     inext = ntuple(x->x+1, Val(K-1))
-    ∆ϕ = angle.(∆z[SVec(inext)] ./ ∆z[SVec(icurr)])  # angle returns value between -π and π
+    ∆ϕ = angle.(∆z[SVector(inext)] ./ ∆z[SVector(icurr)])  # angle returns value between -π and π
 
     # Check all the angle increases are positive.  If they aren't, the polygon is not convex.
     all(∆ϕ .> 0) || throw("v = $v should represent vertices of convex polygon.")
 
-    n = [∆v[2,:] -∆v[1,:]]'  # SMat{2,K}; outward normal directions to edges
+    n = [∆v[2,:] -∆v[1,:]]'  # SMatrix{2,K}; outward normal directions to edges
     n = n ./ hypot.(n[1,:], n[2,:])'  # normalize
 
     return Polygon{K,2K}(v,n)
 end
 
-Polygon(v::AbsMatReal) = (K = size(v,2); Polygon(SMat{2,K}(v)))
+Polygon(v::AbstractMatrix{<:Real}) = (K = size(v,2); Polygon(SMatrix{2,K}(v)))
 
 # Regular polygon
-function Polygon{K}(c::SReal{2},
+function Polygon{K}(c::SVector{2,<:Real},
                     r::Real,  # distance between center and each vertex
                     θ::Real=0.0  # angle from +y-direction towards first vertex
                     ) where {K}
     ∆θ = 2π / K
 
-    θs = π/2 + θ .+ ∆θ .* SVec(ntuple(k->k-1, Val(K)))  # SVec{K}: angles of vertices
-    v = c .+ r .* [cos.(θs) sin.(θs)]'  # SMat{2,K}: locations of vertices
+    θs = π/2 + θ .+ ∆θ .* SVector(ntuple(k->k-1, Val(K)))  # SVector{K}: angles of vertices
+    v = c .+ r .* [cos.(θs) sin.(θs)]'  # SMatrix{2,K}: locations of vertices
 
     return Polygon(v)
 end
 
-Polygon{K}(c::AbsVecReal,  # [x, y]: center of regular polygon
+Polygon{K}(c::AbstractVector{<:Real},  # [x, y]: center of regular polygon
            r::Real,  # radius: distance from center to vertices
            θ::Real=0.0  # angle of first vertex
            ) where {K} =
-   Polygon{K}(SVec{2}(c), r, θ)
+   Polygon{K}(SVector{2}(c), r, θ)
 
 
 Base.:(==)(s1::Polygon, s2::Polygon) = s1.v==s2.v && s1.n==s2.n  # assume sorted v
 Base.isapprox(s1::Polygon, s2::Polygon) = s1.v≈s2.v && s1.n≈s2.n  # assume sorted v
 Base.hash(s::Polygon, h::UInt) = hash(s.v, hash(s.n, hash(:Polygon, h)))
 
-function level(x::SReal{2}, s::Polygon)
+function level(x::SVector{2,<:Real}, s::Polygon)
     c = mean(s.v, dims=Val(2))  # center of mass
 
     d = sum(s.n .* (x .- c), dims=Val(1))
@@ -73,15 +73,15 @@ function level(x::SReal{2}, s::Polygon)
     return 1.0 - maximum(d ./ r)
 end
 
-function surfpt_nearby(x::SReal{2}, s::Polygon{K}) where {K}
+function surfpt_nearby(x::SVector{2,<:Real}, s::Polygon{K}) where {K}
     # Calculate the signed distances from x to edge lines.
-    ∆xe = sum(s.n .* (x .- s.v), dims=Val(1))[1,:]  # SVec{K}: values of equations of edge lines
-    abs∆xe = abs.(∆xe)  # SVec{K}
+    ∆xe = sum(s.n .* (x .- s.v), dims=Val(1))[1,:]  # SVector{K}: values of equations of edge lines
+    abs∆xe = abs.(∆xe)  # SVector{K}
 
     # Determine if x is outside of edges, inclusive.
-    sz = abs.((-)(bounds(s)...))  # SVec{2}
-    onbnd = abs∆xe .≤ τᵣ₀ * maximum(sz)  # SVec{K}
-    isout = (∆xe.>0) .| onbnd  # SVec{K}
+    sz = abs.((-)(bounds(s)...))  # SVector{2}
+    onbnd = abs∆xe .≤ rtol(maximum(sz))  # SVector{K}
+    isout = (∆xe.>0) .| onbnd  # SVector{K}
 
     # For x inside the polygon, it is easy to find the closest surface point: we can simply
     # pick the closest edge and find its point closest to x.
@@ -128,7 +128,7 @@ function surfpt_nearby(x::SReal{2}, s::Polygon{K}) where {K}
     return surf, nout
 end
 
-translate(s::Polygon, ∆::SReal{2}) = (s2 = deepcopy(s); s2.v = s2.v .+ ∆; s2)
+translate(s::Polygon, ∆::SVector{2,<:Real}) = (s2 = deepcopy(s); s2.v = s2.v .+ ∆; s2)
 
 function bounds(s::Polygon)
     l = minimum(s.v, dims=Val(2))[:,1]

--- a/src/planar/special.jl
+++ b/src/planar/special.jl
@@ -7,11 +7,11 @@ export Isosceles, Trapezoid  # constructor-like methods (a.k.a factory methods)
 # To-dos: parallegram, rhombus, ...
 
 # Isosceles triangle
-function Isosceles(base::Tuple2{SReal{2}},  # (end point 1, end point 2): two end points of base
+function Isosceles(base::NTuple{2,SVector{2,<:Real}},  # (end point 1, end point 2): two end points of base
                    h::Real)  # height drawn normal to base; direction is π/2 from base[2]-base[1]
     m = (base[1] + base[2]) / 2  # midpoint of base
     b̂ = normalize(base[2] - base[1])  # unit direction of base
-    ĥ = SVec(-b̂[2], b̂[1])  # unit direction of height
+    ĥ = SVector(-b̂[2], b̂[1])  # unit direction of height
     p = m + h.*ĥ  # apex
 
     v = [base[1] base[2] p]  # vertices
@@ -19,27 +19,27 @@ function Isosceles(base::Tuple2{SReal{2}},  # (end point 1, end point 2): two en
     return Polygon(v)
 end
 
-Isosceles(base::Tuple2{AbsVecReal}, h::Real) = Isosceles(SVec{2}.(base), h)
+Isosceles(base::NTuple{2,AbstractVector{<:Real}}, h::Real) = Isosceles(SVector{2}.(base), h)
 
-function Isosceles(c::SReal{2},  # midpoint of base
+function Isosceles(c::SVector{2,<:Real},  # midpoint of base
                    b::Real,  # base length
                    h::Real,  # height
                    θ::Real=0.0)  # height direction measured from +y-direction (= base direction measured from +x-direction )
     b2 = 0.5b
-    b̂ = SVec(cos(θ), sin(θ))
+    b̂ = SVector(cos(θ), sin(θ))
     base = (c - b2.*b̂, c + b2.*b̂)
 
     return Isosceles(base, h)
 end
 
-Isosceles(c::AbsVecReal, b::Real, h::Real, θ::Real=0.0) = Isosceles(SVec{2}(c), b, h, θ)
+Isosceles(c::AbstractVector{<:Real}, b::Real, h::Real, θ::Real=0.0) = Isosceles(SVector{2}(c), b, h, θ)
 
 # Trapezoid
-function Trapezoid(base::Tuple2{SReal{2}},  # (end point 1, end point 2): two end points of base
+function Trapezoid(base::NTuple{2,SVector{2,<:Real}},  # (end point 1, end point 2): two end points of base
                    h::Real,  # height drawn normal to base; direction is π/2 from base[2]-base[1]
-                   ϕ::Tuple2{Real})  # (base angle 1, base angle 2)
+                   ϕ::NTuple{2,Real})  # (base angle 1, base angle 2)
     b̂ = normalize(base[2] - base[1])  # unit direction of base
-    ĥ = SVec(-b̂[2], b̂[1])  # unit direction of height
+    ĥ = SVector(-b̂[2], b̂[1])  # unit direction of height
 
     t₁ = base[1] + (h*cot(ϕ[1])) .* b̂ + h.*ĥ
     t₂ = base[2] - (h*cot(ϕ[2])) .* b̂ + h.*ĥ
@@ -49,25 +49,25 @@ function Trapezoid(base::Tuple2{SReal{2}},  # (end point 1, end point 2): two en
     return Polygon(v)
 end
 
-Trapezoid(base::Tuple2{AbsVecReal}, h::Real, ϕ::Tuple2{Real}) =
-    Trapezoid(SVec{2}.(base), h, ϕ)
+Trapezoid(base::NTuple{2,AbstractVector{<:Real}}, h::Real, ϕ::NTuple{2,Real}) =
+    Trapezoid(SVector{2}.(base), h, ϕ)
 
-function Trapezoid(c::SReal{2},  # midpoint of base
+function Trapezoid(c::SVector{2,<:Real},  # midpoint of base
                    b::Real,  # base length
                    h::Real,  # height
-                   ϕ::Tuple2{Real},  # (base angle 1, base angle 2)
+                   ϕ::NTuple{2,Real},  # (base angle 1, base angle 2)
                    θ::Real=0.0)  # height direction measured from +y-direction (= base direction measured from +x-direction)
     b2 = 0.5b
-    b̂ = SVec(cos(θ), sin(θ))
+    b̂ = SVector(cos(θ), sin(θ))
     base = (c - b2.*b̂, c + b2.*b̂)
 
     return Trapezoid(base, h, ϕ)
 end
 
-Trapezoid(c::AbsVecReal, b::Real, h::Real, ϕ::Tuple2{Real}, θ::Real=0.0) =
-    Trapezoid(SVec{2}(c), b, h, ϕ, θ)
+Trapezoid(c::AbstractVector{<:Real}, b::Real, h::Real, ϕ::NTuple{2,Real}, θ::Real=0.0) =
+    Trapezoid(SVector{2}(c), b, h, ϕ, θ)
 
 
 # Isosceles trapezoid
-Trapezoid(base::Tuple2{AbsVecReal}, h::Real, ϕ::Real) = Trapezoid(base, h, (ϕ,ϕ))
-Trapezoid(c::AbsVecReal, b::Real, h::Real, ϕ::Real, θ::Real=0.0) = Trapezoid(c, b, h, (ϕ,ϕ), θ)
+Trapezoid(base::NTuple{2,AbstractVector{<:Real}}, h::Real, ϕ::Real) = Trapezoid(base, h, (ϕ,ϕ))
+Trapezoid(c::AbstractVector{<:Real}, b::Real, h::Real, ϕ::Real, θ::Real=0.0) = Trapezoid(c, b, h, (ϕ,ϕ), θ)

--- a/src/prism/cylinder.jl
+++ b/src/prism/cylinder.jl
@@ -6,23 +6,23 @@ const Cylinder = Prism{Ball{2,4}}
 # constructor Prism{Ball{2,4,Nothing}}(c, ...) because Cylinder = Prism{Ball{2,4,Nothing}},
 # which is not what we want.
 # To call the outer constructor of Prism, we should call Prism(c, ...) instead of Cylinder(c, ...).
-Cylinder(c::SReal{3},
+Cylinder(c::SVector{3,<:Real},
          r::Real,
          h::Real=Inf,
-         a::SReal{3}=SVec(0.0,0.0,1.0)) =
-    (â = normalize(a); Prism(c, Ball(SVec(0.0,0.0),r), h, [orthoaxes(â)... â]))
+         a::SVector{3,<:Real}=SVector(0.0,0.0,1.0)) =
+    (â = normalize(a); Prism(c, Ball(SVector(0.0,0.0),r), h, [orthoaxes(â)... â]))
 
-Cylinder(c::AbsVecReal,  # center of cylinder
+Cylinder(c::AbstractVector{<:Real},  # center of cylinder
          r::Real,  # radius of base
          h::Real=Inf,  # height of cylinder
-         a::AbsVecReal=[0.0,0.0,1.0]) =  # axis direction of cylinder
-    Cylinder(SVec{3}(c), r, h, SVec{3}(a))
+         a::AbstractVector{<:Real}=[0.0,0.0,1.0]) =  # axis direction of cylinder
+    Cylinder(SVector{3}(c), r, h, SVector{3}(a))
 
 # Return the bounds of the center cut with respect to the prism center.
 function bounds_ctrcut(s::Cylinder)
     ax = s.p'  # prism axes: columns are not only unit vectors, but also orthogonal
     r = s.b.r
-    el = Ellipsoid(SVec(0.0,0.0,0.0), SVec(r,r,0.0), ax)  # center is set at origin to return bounds with respect to prism center
+    el = Ellipsoid(SVector(0.0,0.0,0.0), SVector(r,r,0.0), ax)  # center is set at origin to return bounds with respect to prism center
 
     return bounds(el)
 end

--- a/src/prism/polygonal.jl
+++ b/src/prism/polygonal.jl
@@ -6,24 +6,24 @@ const PolygonalPrism{K,K2} = Prism{Polygon{K,K2}}
 # constructor Prism{Polygon{K,K2,Nothing}}(c, ...) because PolygonalPrism = Prism{Polygon{K,K2,Nothing}},
 # which is not what we want.
 # To call the outer constructor of Prism, we should call Prism(c, ...) instead of PolygonalPrism(c, ...).
-PolygonalPrism(c::SReal{3},
-               v::SMat{2,K,<:Real},  # 2D coordinates of base vertices in projected prism coordinates
+PolygonalPrism(c::SVector{3,<:Real},
+               v::SMatrix{2,K,<:Real},  # 2D coordinates of base vertices in projected prism coordinates
                h::Real=Inf,
-               a::SReal{3}=SVec(0.0,0.0,1.0)
+               a::SVector{3,<:Real}=SVector(0.0,0.0,1.0)
                ) where {K} =
     (â = normalize(a); Prism(c, Polygon(v), h, [orthoaxes(â)... â]))
 
-PolygonalPrism(c::AbsVecReal,  # center of prism
-               v::AbsMatReal,  # vertices of base polygon
+PolygonalPrism(c::AbstractVector{<:Real},  # center of prism
+               v::AbstractMatrix{<:Real},  # vertices of base polygon
                h::Real=Inf,  # height of prism
-               a::AbsVecReal=[0.0,0.0,1.0]) =  # axis direction of prism
-    (K = size(v,1); PolygonalPrism(SVec{3}(c), SMat{2,K}(v), h, SVec{3}(a)))
+               a::AbstractVector{<:Real}=[0.0,0.0,1.0]) =  # axis direction of prism
+    (K = size(v,1); PolygonalPrism(SVector{3}(c), SMatrix{2,K}(v), h, SVector{3}(a)))
 
 # Return the bounds of the center cut with respect to the prism center.
 function bounds_ctrcut(s::PolygonalPrism{K}) where {K}
     p = s.p'  # projection matrix to prism coordinates: rows are not only unit vectors, but also orthogonal
-    v = [s.b.v; @SMatrix(zeros(1,K))]  # SMat{3,K}: 3D vectices in prism axis coordinates
-    w = p * v  # SMat{3,K}: vertices in external coordinates
+    v = [s.b.v; @SMatrix(zeros(1,K))]  # SMatrix{3,K}: 3D vectices in prism axis coordinates
+    w = p * v  # SMatrix{3,K}: vertices in external coordinates
 
     return minimum(w, dims=Val(2))[:,1], maximum(w, dims=Val(2))[:,1]
 end

--- a/src/prism/prism.jl
+++ b/src/prism/prism.jl
@@ -9,7 +9,7 @@
 # accepts any base shape.  We could use Shape2 to create a 2D base shape and store it as
 # a base shape.  However there is one problem.  We want to use
 #
-#   surfpt_nearby(x_base::SVec{2}, shape_base::Shape2)
+#   surfpt_nearby(x_base::SVector{2}, shape_base::Shape2)
 #
 # to find the closest point in the base dimension (such a point is on the side of the prism),
 # and compare the distance to it with the distance from x to the base plane along the axis
@@ -33,59 +33,59 @@
 export Prism
 
 mutable struct Prism{B<:Shape2} <: Shape3
-    c::SFloat{3}  # prism center
+    c::SVector{3,Float64}  # prism center
     b::B  # base shape described in prism coordinates (i.e, when translating prism, do not need to translate b)
-    h2::Float  # height * 0.5
-    p::S²Float{3,9}  # projection matrix to prism coordinates; must be orthonormal (see surfpt_nearby)
+    h2::Float64  # height * 0.5
+    p::SMatrix{3,3,Float64,9}  # projection matrix to prism coordinates; must be orthonormal (see surfpt_nearby)
     Prism{B}(c,b,h2,p) where {B} = new(c,b,h2,p)  # suppress default outer constructor
 end
 
-Prism(c::SReal{3},
+Prism(c::SVector{3,<:Real},
       b::B,
       h::Real=Inf,
-      axes::S²Real{3,9}=S²Float{3,9}(I)  # columns are axes vectors: first two columns span prism base, and last column is prism axis
+      axes::SMatrix{3,3,<:Real,9}=SMatrix{3,3,Float64}(I)  # columns are axes vectors: first two columns span prism base, and last column is prism axis
       ) where {B<:Shape2} =
     Prism{B}(c, b, 0.5h, inv(axes ./ sqrt.(sum(abs2,axes,dims=Val(1)))))
 
-Prism(c::AbsVecReal, b::Shape2, h::Real=Inf, axes::AbsMatReal=MatFloat(I,length(c),length(c))) =
-    Prism(SVec{3}(c), b, h, S²Mat{3}(axes))
+Prism(c::AbstractVector{<:Real}, b::Shape2, h::Real=Inf, axes::AbstractMatrix{<:Real}=Matrix{Float64}(I,length(c),length(c))) =
+    Prism(SVector{3}(c), b, h, SMatrix{3,3}(axes))
 
 Base.:(==)(s1::Prism, s2::Prism) = s1.c==s2.c && s1.b==s2.b && s1.h2==s2.h2 && s1.p==s2.p
 Base.isapprox(s1::Prism, s2::Prism) = s1.c≈s2.c && s1.b≈s2.b && s1.h2≈s2.h2 && s1.p≈s2.p
 Base.hash(s::Prism, h::UInt) = hash(s.c, hash(s.b, hash(s.h2, hash(s.p, hash(:Prism, h)))))
 
-function level(x::SReal{3}, s::Prism)
+function level(x::SVector{3,<:Real}, s::Prism)
     y = s.p * (x - s.c)  # coordinates after projection
     ya = y[3]  # scalar: coordinate in axis dimension
-    yb = y[SVec(1,2)]  # SVec{2}: coordinate in base dimensions
+    yb = y[SVector(1,2)]  # SVector{2}: coordinate in base dimensions
 
     return min(1.0 - abs(ya)/s.h2, level(yb,s.b))
 end
 
-function surfpt_nearby(x::SReal{3}, s::Prism)
+function surfpt_nearby(x::SVector{3,<:Real}, s::Prism)
     ax = s.p'  # prism axes: columns are not only unit vectors, but also orthogonal
 
     y = s.p * (x - s.c)  # x in prism coordinates
     ya = y[3]  # scalar: coordinate in axis dimension
-    yb = y[SVec(1,2)]  # SVec{2}: coordinates in base dimensions
+    yb = y[SVector(1,2)]  # SVector{2}: coordinates in base dimensions
 
     la = abs(ya)
     abs∆a = abs(s.h2 - la)  # scalar: distance between x and base point closest to x
-    surfa = SVec(yb..., copysign(s.h2, ya))  # SVec{3}: coordinates of base point closest to x
-    nouta = SVec(0.0, 0.0, copysign(1.0, ya))  # SVec{3}: outward direction normal at surfa
-    onbnda = abs∆a ≤ τᵣ₀ * s.h2
+    surfa = SVector(yb..., copysign(s.h2, ya))  # SVector{3}: coordinates of base point closest to x
+    nouta = SVector(0.0, 0.0, copysign(1.0, ya))  # SVector{3}: outward direction normal at surfa
+    onbnda = abs∆a ≤ rtol(s.h2)
     isouta = s.h2<la || onbnda
 
-    surfb2, noutb2 = surfpt_nearby(yb, s.b)  # (SVec{2}, SVec{2}): side point closest to x and outward direction normal to side there
+    surfb2, noutb2 = surfpt_nearby(yb, s.b)  # (SVector{2}, SVector{2}): side point closest to x and outward direction normal to side there
     abs∆b = norm(surfb2 - yb)  # scalar: distance between x and side point closest to x
-    surfb = SVec(surfb2..., ya)  # SVec{3}: coordinates of side point closest to x
-    noutb = SVec(noutb2..., 0.0)  # SVec{3}: outward direction normal to side surface at surfb
-    basesize = abs.((-)(bounds(s.b)...))  # SVec{2}: size of bounding rectancle of base
-    onbndb = abs∆b ≤ τᵣ₀ * maximum(basesize)
+    surfb = SVector(surfb2..., ya)  # SVector{3}: coordinates of side point closest to x
+    noutb = SVector(noutb2..., 0.0)  # SVector{3}: outward direction normal to side surface at surfb
+    basesize = abs.((-)(bounds(s.b)...))  # SVector{2}: size of bounding rectancle of base
+    onbndb = abs∆b ≤ rtol(maximum(basesize))
     isoutb = yb∉s.b || onbndb
 
     if isouta && isoutb  # x outside in both axis and base dimensions
-        surf = SVec(surfb[1], surfb[2], surfa[3])
+        surf = SVector(surfb[1], surfb[2], surfa[3])
         nout = (onbnda && onbndb) ? (noutb + nouta) : (y - surf)
         nout = norm(nout)==Inf ? isinf.(nout) .* sign.(nout) : normalize(nout)  # e.g., return [0,0,-1] for nout = [1,-2,-Inf]
     elseif !isouta && isoutb  # x outside in base dimensions, but inside prism in axis dimension
@@ -101,12 +101,12 @@ end
 
 function bounds(s::Prism)
     ax = s.p'  # prism axes: columns are not only unit vectors, but also orthogonal
-    a = ax[:,3]  # SVec{3}
+    a = ax[:,3]  # SVector{3}
     h2a = s.h2 * a
 
-    l0, u0 = bounds_ctrcut(s)  # (SVec{3}, SVec{3})
-    l1, u1 = l0+h2a, u0+h2a  # (SVec{3}, SVec{3})
-    l2, u2 = l0-h2a, u0-h2a  # (SVec{3}, SVec{3})
+    l0, u0 = bounds_ctrcut(s)  # (SVector{3}, SVector{3})
+    l1, u1 = l0+h2a, u0+h2a  # (SVector{3}, SVector{3})
+    l2, u2 = l0-h2a, u0-h2a  # (SVector{3}, SVector{3})
 
     return min.(l1,l2)+s.c, max.(u1,u2)+s.c
 end

--- a/src/prism/sectoral.jl
+++ b/src/prism/sectoral.jl
@@ -6,48 +6,48 @@ const SectoralPrism = Prism{Sector}
 # constructor Prism{Sector{Nothing}}(c, ...) because SectoralPrism = Prism{Sector{Nothing}},
 # which is not what we want.
 # To call the outer constructor of Prism, we should call Prism(c, ...) instead of SectoralPrism(c, ...).
-SectoralPrism(c::SReal{3},
+SectoralPrism(c::SVector{3,<:Real},
               r::Real,
               ϕ::Real,
               ∆ϕ::Real,
               h::Real=Inf,
-              a::SReal{3}=SVec(0.0,0.0,1.0)
-              ) where {K} =
-    (â = normalize(a); Prism(c, Sector(SVec(0.0,0.0),r,ϕ,∆ϕ), h, [orthoaxes(â)... â]))
+              a::SVector{3,<:Real}=SVector(0.0,0.0,1.0)
+              ) =
+    (â = normalize(a); Prism(c, Sector(SVector(0.0,0.0),r,ϕ,∆ϕ), h, [orthoaxes(â)... â]))
 
-SectoralPrism(c::AbsVecReal,  # center of prism
+SectoralPrism(c::AbstractVector{<:Real},  # center of prism
               r::Real,  # radius of sectoral base
               ϕ::Real,  # start angle of sectoral base: 0 ≤ ϕₛ < 2π  (2π excluded)
               ∆ϕ::Real,  # end angle sectoral base: 0 ≤ ϕₑ-ϕₛ ≤ 2π
               h::Real=Inf,  # height of prism
-              a::AbsVecReal=[0.0,0.0,1.0]) =  # axis direction of prism
-    SectoralPrism(SVec{3}(c), r, ϕ, ∆ϕ, h, SVec{3}(a))
+              a::AbstractVector{<:Real}=[0.0,0.0,1.0]) =  # axis direction of prism
+    SectoralPrism(SVector{3}(c), r, ϕ, ∆ϕ, h, SVector{3}(a))
 
 function bounds_ctrcut(s::SectoralPrism)
     ax = s.p'  # prism axes: columns are not only unit vectors, but also orthogonal
     if ax ≈ I  # prism axes are aligned with Cartesian directions (this covers most usage)
-        l, u = bounds(s.b)  # (SVec{2}, SVec{2})
-        a₁₂ = ax[:,SVec(1,2)]  # SMat{3,2}
+        l, u = bounds(s.b)  # (SVector{2}, SVector{2})
+        a₁₂ = ax[:,SVector(1,2)]  # SMatrix{3,2}
 
         return a₁₂*l, a₁₂*u
     else  # prism axes are not aligned with Cartesian directions
         b = s.b
         r = b.r
 
-        el = Ellipsoid(SVec(0.0,0.0,0.0), SVec(r,r,0.0), ax)  # center is set at origin to return bounds with respect to prism center
+        el = Ellipsoid(SVector(0.0,0.0,0.0), SVector(r,r,0.0), ax)  # center is set at origin to return bounds with respect to prism center
         bp = boundpts(el)  # S²Mat{3}: boundary points; all three columns of b are free of NaN because no column of ax is aligned with Cartesian directions
         bp′ = s.p * bp  # S²Mat{3}: bp in prism coordinates
-        bp2′ = bp′[SVec(1,2),:]  # SMat{2,3}: in each column of bp′, third entry is in axis dimension, so must be zero mathematically
+        bp2′ = bp′[SVector(1,2),:]  # SMatrix{2,3}: in each column of bp′, third entry is in axis dimension, so must be zero mathematically
 
-        ϕ = atan.(bp2′[2,:], bp2′[1,:])  # SVec{3}: angles of boundary points in base plane
-        ϕsym = [ϕ; ϕ.+π]  # SVec{6}: include symmetric points with respect to base center
-        ϕall = [ϕsym; SVec(b.ϕ₀-b.∆ϕ2, b.ϕ₀+b.∆ϕ2)]  # SVec{8}: angles of all boundary point candidates, except base center
+        ϕ = atan.(bp2′[2,:], bp2′[1,:])  # SVector{3}: angles of boundary points in base plane
+        ϕsym = [ϕ; ϕ.+π]  # SVector{6}: include symmetric points with respect to base center
+        ϕall = [ϕsym; SVector(b.ϕ₀-b.∆ϕ2, b.ϕ₀+b.∆ϕ2)]  # SVector{8}: angles of all boundary point candidates, except base center
 
-        bpall′ = r .* [cos.(ϕall) sin.(ϕall) @SVector(zeros(8))]'  # SMat{3,8}: each column is boundary point candidate in prism coordinates
-        bpall = ax * bpall′  # SMat{3,8}: each column is boundary point candidate in external coordinates
-        bpallc = [bpall SVec(0.0,0.0,0.0)]  # SMat{3,9}: include base center
-        ind = abs.(distangle.(ϕsym, b.ϕ₀)) .≤ b.∆ϕ2  # SVec{6}: indices of angles contained in base arc
-        indallc = [ind; SVec(true,true,true)]  # SVec{9}: include arc ends and base center
+        bpall′ = r .* [cos.(ϕall) sin.(ϕall) @SVector(zeros(8))]'  # SMatrix{3,8}: each column is boundary point candidate in prism coordinates
+        bpall = ax * bpall′  # SMatrix{3,8}: each column is boundary point candidate in external coordinates
+        bpallc = [bpall SVector(0.0,0.0,0.0)]  # SMatrix{3,9}: include base center
+        ind = abs.(distangle.(ϕsym, b.ϕ₀)) .≤ b.∆ϕ2  # SVector{6}: indices of angles contained in base arc
+        indallc = [ind; SVector(true,true,true)]  # SVector{9}: include arc ends and base center
 
         xs = bpallc[1,:]
         ys = bpallc[2,:]
@@ -68,6 +68,6 @@ function bounds_ctrcut(s::SectoralPrism)
             end
         end
 
-        return (SVec(xmin,ymin,zmin), SVec(xmax,ymax,zmax))
+        return (SVector(xmin,ymin,zmin), SVector(xmax,ymax,zmax))
     end
 end

--- a/src/prism/sectoral.jl
+++ b/src/prism/sectoral.jl
@@ -35,8 +35,8 @@ function bounds_ctrcut(s::SectoralPrism)
         r = b.r
 
         el = Ellipsoid(SVector(0.0,0.0,0.0), SVector(r,r,0.0), ax)  # center is set at origin to return bounds with respect to prism center
-        bp = boundpts(el)  # S²Mat{3}: boundary points; all three columns of b are free of NaN because no column of ax is aligned with Cartesian directions
-        bp′ = s.p * bp  # S²Mat{3}: bp in prism coordinates
+        bp = boundpts(el)  # SMatrix{3,3}: boundary points; all three columns of b are free of NaN because no column of ax is aligned with Cartesian directions
+        bp′ = s.p * bp  # SMatrix{3,3}: bp in prism coordinates
         bp2′ = bp′[SVector(1,2),:]  # SMatrix{2,3}: in each column of bp′, third entry is in axis dimension, so must be zero mathematically
 
         ϕ = atan.(bp2′[2,:], bp2′[1,:])  # SVector{3}: angles of boundary points in base plane

--- a/src/util/kdtree.jl
+++ b/src/util/kdtree.jl
@@ -17,10 +17,10 @@ not shapes of nonzero size.)
 mutable struct KDTree{K,S<:Shape{K}}
     s::Vector{S}
     ix::Int
-    x::Float
+    x::Float64
     left::KDTree{K,S}  # shapes ≤ x in coordinate ix
     right::KDTree{K,S} # shapes > x in coordinate ix
-    KDTree{K,S}(s::AbsVec{S}) where {K,S<:Shape{K}} = new(s, 0)
+    KDTree{K,S}(s::AbstractVector{S}) where {K,S<:Shape{K}} = new(s, 0)
     function KDTree{K,S}(ix::Integer, x::Real, left::KDTree{K,S}, right::KDTree{K,S}) where {K,S<:Shape{K}}
         1 ≤ ix ≤ K || throw(BoundsError())
         new(S[], ix, x, left, right)
@@ -30,7 +30,7 @@ end
 Base.ndims(::KDTree{K}) where {K} = K
 
 """
-    KDTree(s::AbsVec{<:Shape{K}})
+    KDTree(s::AbstractVector{<:Shape{K}})
 
 Construct a K-D tree (`KDTree`) representation of a list of
 `shapes` in order to enable rapid searching of an shape list.
@@ -38,7 +38,7 @@ Construct a K-D tree (`KDTree`) representation of a list of
 When searching the tree, shapes that appear earlier in `s`
 take precedence over shapes that appear later.
 """
-function KDTree(s::AbsVec{S}) where {K,S<:Shape{K}}
+function KDTree(s::AbstractVector{S}) where {K,S<:Shape{K}}
     (length(s) ≤ 4 || K == 0) && return KDTree{K,S}(s)
 
     # figure out the best dimension ix to divide over,
@@ -100,7 +100,7 @@ function Base.show(io::IO, ::MIME"text/plain", kd::KDTree)
     _show(io, kd, 0)
 end
 
-function Base.findfirst(p::SVec{N}, s::Vector{S}) where {N,S<:Shape{N}}
+function Base.findfirst(p::SVector{N}, s::Vector{S}) where {N,S<:Shape{N}}
     for i in eachindex(s)
         b = bounds(s[i])
         if all(b[1] .< p .< b[2]) && p ∈ s[i]  # check if p is within bounding box is faster
@@ -110,7 +110,7 @@ function Base.findfirst(p::SVec{N}, s::Vector{S}) where {N,S<:Shape{N}}
     return nothing
 end
 
-function Base.findfirst(p::SVec{N}, kd::KDTree{N}) where {N}
+function Base.findfirst(p::SVector{N}, kd::KDTree{N}) where {N}
     if isempty(kd.s)
         if p[kd.ix] ≤ kd.x
             return findfirst(p, kd.left)
@@ -127,5 +127,5 @@ end
 
 Return the first shape in `kd` that contains the point `p`; return `nothing` otherwise.
 """
-Base.findfirst(p::AbsVecReal, kd::KDTree{N}) where {N} = findfirst(SVec{N}(p), kd)
-Base.findfirst(p::AbsVecReal, s::Vector{<:Shape{N}}) where {N} = findfirst(SVec{N}(p), s)
+Base.findfirst(p::AbstractVector{<:Real}, kd::KDTree{N}) where {N} = findfirst(SVector{N}(p), kd)
+Base.findfirst(p::AbstractVector{<:Real}, s::Vector{<:Shape{N}}) where {N} = findfirst(SVector{N}(p), s)

--- a/src/util/periodize.jl
+++ b/src/util/periodize.jl
@@ -1,9 +1,9 @@
 export periodize
 
-periodize(shp::Shape{N}, A::AbsMatReal, ∆range::Shape{N}) where {N} = periodize(shp, S²Mat{N}(A), ∆range)
+periodize(shp::Shape{N}, A::AbstractMatrix{<:Real}, ∆range::Shape{N}) where {N} = periodize(shp, SMatrix{N,N}(A), ∆range)
 
 function periodize(shp::S,  # shape to periodize
-                   A::S²Real{N},  # columns: primitive vectors of Bravais lattice
+                   A::SMatrix{N,N,<:Real},  # columns: primitive vectors of Bravais lattice
                    ∆range::Shape{N}  # range of translation vectors; boundaries included
 				   ) where {N,S<:Shape{N}}
     # R = n₁a₁ + n₂a₂ + n₃a₃ is a translation vector for A = [a₁ a₂ a₃].  Find the ranges of
@@ -20,20 +20,20 @@ function periodize(shp::S,  # shape to periodize
     # box, all the lattice points within the post-transform parallelpiped are also within
     # the bounding box of the parallelpiped, whose corner indices are the minimum and
     # maximum nᵢ's.
-    ∆bound = bounds(∆range)  # (SVec{3}, SVec{3}): bounds of translation range
-    nmax_fl = SVec(ntuple(k->-Inf, Val(N)))  # [-Inf, -Inf, -Inf] for N = 3
-    nmin_fl = SVec(ntuple(k->Inf, Val(N)))  # [Inf, Inf, Inf] for N = 3
+    ∆bound = bounds(∆range)  # (SVector{3}, SVector{3}): bounds of translation range
+    nmax_fl = SVector(ntuple(k->-Inf, Val(N)))  # [-Inf, -Inf, -Inf] for N = 3
+    nmin_fl = SVector(ntuple(k->Inf, Val(N)))  # [Inf, Inf, Inf] for N = 3
     rcart = CartesianIndices(ntuple(k->2, Val(N)))  # (2,2,2) for N = 3
     for icart = rcart  # icart: CartesianIndex (see, e.g., https://julialang.org/blog/2016/02/iteration)
-        cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVec(icart.I))  # SVec: corner of ∆bound (note icart.I[k] = 1 or 2)
-        n_fl = A \ cnr  # SVec: A * n_fl = corner
-        nmax_fl = max.(nmax_fl, n_fl)  # SVec
-        nmin_fl = min.(nmin_fl, n_fl)  # SVec
+        cnr = map((∆b1,∆b2,i)-> i==1 ? ∆b1 : ∆b2, ∆bound[1], ∆bound[2], SVector(icart.I))  # SVector: corner of ∆bound (note icart.I[k] = 1 or 2)
+        n_fl = A \ cnr  # SVector: A * n_fl = corner
+        nmax_fl = max.(nmax_fl, n_fl)  # SVector
+        nmin_fl = min.(nmin_fl, n_fl)  # SVector
     end
 
     # Find the integral nᵢ's.
-    nmax = ceil.(Int, nmax_fl)  # SVec
-    nmin = floor.(Int, nmin_fl)  # SVec
+    nmax = ceil.(Int, nmax_fl)  # SVector
+    nmin = floor.(Int, nmin_fl)  # SVector
 
     # For nᵢ's within the range calculated above, check if R = n₁a₁ + n₂a₂ + n₃a₃ is within
     # the Shape ∆range.  If it is, then create a shape transformed by R.
@@ -42,7 +42,7 @@ function periodize(shp::S,  # shape to periodize
     ishape = 0
     nrange = map((n1,n2)->n1:n2, nmin.data, nmax.data)  # e.g., (1:10, 1:10, 1:10) for N = 3
     for n = CartesianIndices(nrange)  # n: CartesianIndex
-		∆ = A * SVec(n.I)  # lattice vector R
+		∆ = A * SVector(n.I)  # lattice vector R
 		if ∆ ∈ ∆range
 			shape = translate(shp, ∆)
 			ishape += 1

--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -1,5 +1,3 @@
-const EPS_REL = τᵣ₀  # machine epsilon
-
 # Define drawshape() and drawshape!() functions.
 # hres and vres are the number of sampling points in the corresponding Cartesion derctions.
 # They should be at least 2 because range(start, end, length) with start≠end requires length
@@ -25,21 +23,20 @@ function Makie.plot!(ds::DrawShape{<:Tuple{Shape2}})
     res = (hres, vres)
 
     # Makie.convert_arguments() defined below handles this new signature.
-    contour!(ds, shp, res, levels=SVec(0.0); ds.attributes...)
+    contour!(ds, shp, res, levels=SVector(0.0); ds.attributes...)
 
     return ds
 end
 
 # Define the new signature of contour!() used in drawshape!() for 2D shapes.
-function Makie.convert_arguments(P::SurfaceLike, shp::Shape2, res::Tuple2{Integer})
+function Makie.convert_arguments(P::SurfaceLike, shp::Shape2, res::NTuple{2,Integer})
     lower, upper = bounds(shp)
     ∆ = upper - lower
 
-    ϵrel = EPS_REL
-    nw = 1; xs = range(lower[nw] - ϵrel*∆[nw], upper[nw] + ϵrel*∆[nw], length=res[nw])
-    nw = 2; ys = range(lower[nw] - ϵrel*∆[nw], upper[nw] + ϵrel*∆[nw], length=res[nw])
+    nw = 1; xs = range(lower[nw] - ϵrel*∆[nw], upper[nw] + rtol(∆[nw]), length=res[nw])
+    nw = 2; ys = range(lower[nw] - ϵrel*∆[nw], upper[nw] + rtol(∆[nw]), length=res[nw])
 
-    lvs = [level(SVec(x,y), shp) for x = xs, y = ys]
+    lvs = [level(SVector(x,y), shp) for x = xs, y = ys]
 
     return convert_arguments(P, xs, ys, lvs)
 end

--- a/test/cylinder.jl
+++ b/test/cylinder.jl
@@ -1,9 +1,11 @@
+const ϵ = eps(Float64)
+
 @testset "Cylinder" begin
     c = Cylinder([0,0,0], 0.3, 2.2, [0,0,1])
     @test c == deepcopy(c)
     @test hash(c) == hash(deepcopy(c))
     @test [0.2,0.2,1] ∈ c
-    @test SVec(0.2,0.2,1.2) ∉ c
+    @test SVector(0.2,0.2,1.2) ∉ c
     @test [0.2,0.25,1] ∉ c
 
     @test ((x,nout) = surfpt_nearby([0,0,0],c); (x≈[0,0,1.1] && nout≈[0,0,1]) || (x≈[0.3,0,0] && nout≈[1,0,0]) || (x≈[0,0.3,0] && nout≈[0,1,0]))  # handle point at center properly
@@ -11,9 +13,9 @@
     @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # outside corners
     @test all([(p = [0.3sx,0,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sx = (-1,1), sz = (-1,1)])  # outside corners
     @test all([(p = [0,0.3sy,1.1sz]; surfpt_nearby(1.1p,c) ≈ (p, normalize(1.1p-p))) for sy = (-1,1), sz = (-1,1)])  # outside corners
-    @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 sy 0; 0 0 sz]*nout.≥-10τₐ₀))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # on rims
-    @test all([(p = [0.3sx,0,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 0 sz]*nout.≥-10τₐ₀))) for sx = (-1,1), sz = (-1,1)])  # on rims
-    @test all([(p = [0,0.3sy,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([0 sy 0; 0 0 sz]*nout.≥-10τₐ₀))) for sy = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0.3sx/√2,0.3sy/√2,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 sy 0; 0 0 sz]*nout.≥-10ϵ))) for sx = (-1,1), sy = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0.3sx,0,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([sx 0 0; 0 0 sz]*nout.≥-10ϵ))) for sx = (-1,1), sz = (-1,1)])  # on rims
+    @test all([(p = [0,0.3sy,1.1sz]; (x,nout) = surfpt_nearby(p,c); (x≈p && all([0 sy 0; 0 0 sz]*nout.≥-10ϵ))) for sy = (-1,1), sz = (-1,1)])  # on rims
     @test all([(p = [0.3sx/√2/2,0.3sy/√2/2,1.1sz]; surfpt_nearby([p[1],p[2],ρ*p[3]],c) ≈ (p,[0,0,sz])) for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,0,1), sy = (-1,0,1), sz = (-1,1)])  # around bases
     @test all([(p = [0.3sx,0,1.1sz/2]; surfpt_nearby([ρ*p[1],p[2],p[3]],c) ≈ (p,[sx,0,0])) for ρ = (one⁻⁻,1,one⁺⁺), sx = (-1,1), sz = (-1,0,1)])  # around side
     @test all([(p = [0,0.3sy,1.1sz/2]; surfpt_nearby([p[1],ρ*p[2],p[3]],c) ≈ (p,[0,sy,0])) for ρ = (one⁻⁻,1,one⁺⁺), sy = (-1,1), sz = (-1,0,1)])  # around side
@@ -42,9 +44,9 @@ end  # @testset "Cylinder"
     @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # outside corners
     @test all([(p = 0.3s1*ax1+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s1 = (-1,1), s3 = (-1,1)])  # outside corners
     @test all([(p = 0.3s2*ax2+1.1s3*ax3; surfpt_nearby(1.1p,cr) ≈ (p, normalize(1.1p-p))) for s2 = (-1,1), s3 = (-1,1)])  # outside corners
-    @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s2*ax2 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # on rims
-    @test all([(p = 0.3s1*ax1+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s1 = (-1,1), s3 = (-1,1)])  # on rims
-    @test all([(p = 0.3s2*ax2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s2*ax2 s3*ax3]'*nout.≥-10τₐ₀) && norm(nout)≈1)) for s2 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3(s1*ax1+s2*ax2)/√2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s2*ax2 s3*ax3]'*nout.≥-10ϵ) && norm(nout)≈1)) for s1 = (-1,1), s2 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3s1*ax1+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s1*ax1 s3*ax3]'*nout.≥-10ϵ) && norm(nout)≈1)) for s1 = (-1,1), s3 = (-1,1)])  # on rims
+    @test all([(p = 0.3s2*ax2+1.1s3*ax3; (x,nout) = surfpt_nearby(p,cr); (x≈p && all([s2*ax2 s3*ax3]'*nout.≥-10ϵ) && norm(nout)≈1)) for s2 = (-1,1), s3 = (-1,1)])  # on rims
     @test all([surfpt_nearby(0.3(s1*ax1+s2*ax2)/√2/2+ρ*1.1s3*ax3,cr) ≈ (0.3(s1*ax1+s2*ax2)/√2/2+1.1s3*ax3,s3*ax3) for ρ = (one⁻⁻,1,one⁺⁺), s1 = (-1,0,1), s2 = (-1,0,1), s3 = (-1,1)])  # around bases
     @test all([surfpt_nearby(ρ*0.3s1*ax1+1.1s3*ax3/2,cr) ≈ (0.3s1*ax1+1.1s3*ax3/2, s1*ax1) for ρ = (one⁻⁻,1,one⁺⁺), s1 = (-1,1), s3 = (-1,0,1)])  # around side
     @test all([surfpt_nearby(ρ*0.3s2*ax2+1.1s3*ax3/2,cr) ≈ (0.3s2*ax2+1.1s3*ax3/2, s2*ax2) for ρ = (one⁻⁻,1,one⁺⁺), s2 = (-1,1), s3 = (-1,0,1)])  # around side

--- a/test/kdtree.jl
+++ b/test/kdtree.jl
@@ -11,8 +11,8 @@
     @test findfirst([10.1,1], kd) == nothing
     @test checktree(kd, s)
 
-    s = Shape3[Ball(SVec(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
+    s = Shape3[Ball(SVector(randn(rng),randn(rng),randn(rng)), 0.01) for i=1:100]
     @test checktree(KDTree(s), s)
-    s = Shape3[Ball(SVec(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
+    s = Shape3[Ball(SVector(randn(rng),randn(rng),randn(rng)), 0.1) for i=1:100]
     @test checktree(KDTree(s), s)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
 using GeometryPrimitives
-using AbbreviatedTypes
+using StaticArrays
 using LinearAlgebra
 using Random: MersenneTwister
 using Statistics: mean
 using Test
 
-const one⁻ = 1 - τᵣ₀  # scale factor slightly less than 1
-const one⁺ = 1 + τᵣ₀  # scare factor slightly greater than 1
+const one⁻ = 1 - 1e-8  # scale factor slightly less than 1
+const one⁺ = 1 + 1e-8  # scare factor slightly greater than 1
 const one⁻⁻, one⁺⁺ = 0.9, 1.1  # (scale factor less than 1, scale factor greater than 1)
 
 Base.isapprox(a::Tuple, b::Tuple; kws...) = all(p -> isapprox(p...; kws...), zip(a,b))
@@ -33,8 +33,8 @@ function checkbounds(s::Shape{N}, ntrials=10^4) where {N}
 end
 
 function checktree(t::KDTree{N}, slist::Vector{<:Shape{N}}, ntrials=10^3) where {N}
-    lb = SVec{N}(fill(Inf,N))
-    ub = SVec{N}(fill(-Inf,N))
+    lb = SVector{N}(fill(Inf,N))
+    ub = SVector{N}(fill(-Inf,N))
     for i in eachindex(slist)
         lbi,ubi = bounds(slist[i])
         lb = min.(lb,lbi)

--- a/test/vxlcut.jl
+++ b/test/vxlcut.jl
@@ -1,31 +1,31 @@
 @testset "triangular cylinder 3D" begin
-    vxl = (SVec(0,0,0), SVec(1,1,1))
-    nout = SVec(1,1,0)
+    vxl = (SVector(0,0,0), SVector(1,1,1))
+    nout = SVector(1,1,0)
 
-    @test_nowarn (r₀ = SVec(0.5,0,0); @inferred(volfrac(vxl, nout, r₀)))
-    @test (r₀ = SVec(0.5,0,0); volfrac(vxl, nout, r₀) ≈ 0.125)
-    @test (r₀ = SVec(0.5,0,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
-    @test (r₀ = SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0,0); nout = SVec(1,2,0); volfrac(vxl, nout, r₀) ≈ 0.25)
-    @test (r₀ = SVec(1,0,0); nout = SVec(1,2,0); volfrac(vxl, -nout, r₀) ≈ 0.75)
+    @test_nowarn (r₀ = SVector(0.5,0,0); @inferred(volfrac(vxl, nout, r₀)))
+    @test (r₀ = SVector(0.5,0,0); volfrac(vxl, nout, r₀) ≈ 0.125)
+    @test (r₀ = SVector(0.5,0,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
+    @test (r₀ = SVector(1,0,0); volfrac(vxl, nout, r₀) ≈ 0.5)
+    @test (r₀ = SVector(1,0,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
+    @test (r₀ = SVector(1,0,0); nout = SVector(1,2,0); volfrac(vxl, nout, r₀) ≈ 0.25)
+    @test (r₀ = SVector(1,0,0); nout = SVector(1,2,0); volfrac(vxl, -nout, r₀) ≈ 0.75)
 end  # @testset "triangular cylinder 3D"
 
 @testset "triangular cylinder 2D" begin
-    vxl = (SVec(0,0), SVec(1,1))
-    nout = SVec(1,1)
+    vxl = (SVector(0,0), SVector(1,1))
+    nout = SVector(1,1)
 
-    @test_nowarn (r₀ = SVec(0.5,0); @inferred(volfrac(vxl, nout, r₀)))
-    @test (r₀ = SVec(0.5,0); volfrac(vxl, nout, r₀) ≈ 0.125)
-    @test (r₀ = SVec(0.5,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
-    @test (r₀ = SVec(1,0); volfrac(vxl, nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
-    @test (r₀ = SVec(1,0); nout = SVec(1,2); volfrac(vxl, nout, r₀) ≈ 0.25)
-    @test (r₀ = SVec(1,0); nout = SVec(1,2); volfrac(vxl, -nout, r₀) ≈ 0.75)
+    @test_nowarn (r₀ = SVector(0.5,0); @inferred(volfrac(vxl, nout, r₀)))
+    @test (r₀ = SVector(0.5,0); volfrac(vxl, nout, r₀) ≈ 0.125)
+    @test (r₀ = SVector(0.5,0); volfrac(vxl, -nout, r₀) ≈ 0.875)
+    @test (r₀ = SVector(1,0); volfrac(vxl, nout, r₀) ≈ 0.5)
+    @test (r₀ = SVector(1,0); volfrac(vxl, -nout, r₀) ≈ 0.5)
+    @test (r₀ = SVector(1,0); nout = SVector(1,2); volfrac(vxl, nout, r₀) ≈ 0.25)
+    @test (r₀ = SVector(1,0); nout = SVector(1,2); volfrac(vxl, -nout, r₀) ≈ 0.75)
 end  # @testset "triangular cylinder 2D"
 
 @testset "quadrangular cylinder 3D" begin
-    @test_nowarn @inferred(volfrac((SVec(0,0,0),SVec(1,1,1)), SVec(1,2,0), SVec(0.5,0.5,0.5)))
+    @test_nowarn @inferred(volfrac((SVector(0,0,0),SVector(1,1,1)), SVector(1,2,0), SVector(0.5,0.5,0.5)))
     @test begin
         result = true
         for i = 1:100
@@ -33,14 +33,14 @@ end  # @testset "triangular cylinder 2D"
             r₀ = mean(vxl)
             nout = randn(3)
             nout[rand(1:3)] = 0
-            result &= volfrac(vxl, SVec{3}(nout), r₀)≈0.5
+            result &= volfrac(vxl, SVector{3}(nout), r₀)≈0.5
         end
         result
     end
 end  # @testset "quadrangular cylinder 3D"
 
 @testset "quadrangular cylinder 2D" begin
-    @test_nowarn @inferred(volfrac((SVec(0,0),SVec(1,1)), SVec(1,2), SVec(0.5,0.5)))
+    @test_nowarn @inferred(volfrac((SVector(0,0),SVector(1,1)), SVector(1,2), SVector(0.5,0.5)))
     @test begin
         result = true
         for i = 1:100
@@ -55,7 +55,7 @@ end  # @testset "quadrangular cylinder 2D"
 
 @testset "general cases" begin
     # Test random cases.
-    @test_nowarn @inferred(volfrac((-@SVector(rand(3)),@SVector(rand(3))), SVec(0,0,0), @SVector(randn(3))))
+    @test_nowarn @inferred(volfrac((-@SVector(rand(3)),@SVector(rand(3))), SVector(0,0,0), @SVector(randn(3))))
     @test begin
         result = true
         for i = 1:100
@@ -79,33 +79,33 @@ end  # @testset "quadrangular cylinder 2D"
     end
 
     # Test boundary cases.
-    vxl = (SVec(0,0,0), SVec(1,1,1))
-    r₀ = SVec(0,0,0)
-    @test (nout = SVec(1,0,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,0,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(1,1,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,-1,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(1,1,1); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
-    @test (nout = SVec(-1,-1,-1); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
-    @test (nout = SVec(-1,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_tricyl()
-    @test (nout = SVec(-1,-1,1); volfrac(vxl, nout, r₀) ≈ 5/6)  # rvol_gensect()
-    @test (nout = SVec(1,-2,1); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadsect()
-    r₀ = SVec(0.5,0.5,0)
-    @test (nout = SVec(-2,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadcyl()
+    vxl = (SVector(0,0,0), SVector(1,1,1))
+    r₀ = SVector(0,0,0)
+    @test (nout = SVector(1,0,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = SVector(-1,0,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = SVector(1,1,0); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = SVector(-1,-1,0); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = SVector(1,1,1); volfrac(vxl, nout, r₀) ≈ 0)  # completely outside
+    @test (nout = SVector(-1,-1,-1); volfrac(vxl, nout, r₀) ≈ 1)  # completely inside
+    @test (nout = SVector(-1,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_tricyl()
+    @test (nout = SVector(-1,-1,1); volfrac(vxl, nout, r₀) ≈ 5/6)  # rvol_gensect()
+    @test (nout = SVector(1,-2,1); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadsect()
+    r₀ = SVector(0.5,0.5,0)
+    @test (nout = SVector(-2,1,0); volfrac(vxl, nout, r₀) ≈ 0.5)  # rvol_quadcyl()
 
     # Test tolerance to floating-point arithmetic.
-    vxl = (SVec(0,9.5,0), SVec(1,10.5,1))
-    r₀ = SVec(0.5,10.0,0.5)
-    nout = SVec(0.0,1/√2,1/√2)
+    vxl = (SVector(0,9.5,0), SVector(1,10.5,1))
+    r₀ = SVector(0.5,10.0,0.5)
+    nout = SVector(0.0,1/√2,1/√2)
     @test volfrac(vxl, nout, r₀) ≈ 0.5
 
     # Test rvol_quadsect() for nontrivial cases.
-    vxl = (SVec(0,0,0), SVec(1,1,2))
-    r₀ = SVec(0.5, 0.5, 0.5)
+    vxl = (SVector(0,0,0), SVector(1,1,2))
+    r₀ = SVector(0.5, 0.5, 0.5)
     @test begin
         result = true
         for i = 1:100
-            nout = SVec(randn()/20, randn()/20, 1)
+            nout = SVector(randn()/20, randn()/20, 1)
             result &= volfrac(vxl, nout, r₀)≈0.5/2
         end
         result


### PR DESCRIPTION
@wsshin, I'm not really a fan of using AbbreviatedTypes here — I think it makes the code much harder to read for anyone who isn't you, since most of the Julia community does not use these abbreviations. 

This PR shouldn't affect any of your code using GeometryPrimitives, since the API is the same — the types are not changed, just spelled differently internally.

Closes #40.